### PR TITLE
publish source code jar 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,14 @@ publishing {
             version '0.1-SNAPSHOT'
 
             from components.java
+            
+            artifact sourceJar
         }
     }
 }
+
+task sourceJar(type: Jar) {
+  classifier = 'sources'
+  from sourceSets.main.allJava
+}
+


### PR DESCRIPTION
So that I can step through library source code I need to publish the source jar to Maven Local as well. Update build.gradle to enable this.