### PR TITLE
remove org.json:json, javax.ws.rs deps and upgrade gson dep to 2.8.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,12 +29,9 @@ dependencies {
     // Use JUnit test framework
     testImplementation 'junit:junit:4.12'
     
-    compile 'com.google.code.gson:gson:2.2.4'
-    compile 'org.json:json:20141113'
-    compile group: 'javax.ws.rs', name: 'javax.ws.rs-api', version: '2.0-m02'
+    compile 'com.google.code.gson:gson:2.8.2'
     
-    // https://mvnrepository.com/artifact/com.sun.jersey/jersey-server
-	compile group: 'com.sun.jersey', name: 'jersey-server', version: '1.19.4'
+    compile 'com.sun.jersey:jersey-server:1.19.4'
 }
 
 publishing {

--- a/src/main/java/com/microsoft/graph/http/GraphServiceException.java
+++ b/src/main/java/com/microsoft/graph/http/GraphServiceException.java
@@ -22,19 +22,18 @@
 
 package com.microsoft.graph.http;
 
-import com.microsoft.graph.core.ClientException;
-import com.microsoft.graph.core.GraphErrorCodes;
-import com.microsoft.graph.options.HeaderOption;
-import com.microsoft.graph.serializer.ISerializer;
-
-import org.json.JSONException;
-import org.json.JSONObject;
-
 import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.microsoft.graph.core.ClientException;
+import com.microsoft.graph.core.GraphErrorCodes;
+import com.microsoft.graph.options.HeaderOption;
+import com.microsoft.graph.serializer.ISerializer;
 
 /**
  * An exception from the Graph service.
@@ -60,11 +59,6 @@ public class GraphServiceException extends ClientException {
      * The number of bytes to display when showing byte array.
      */
     protected static final int MAX_BYTE_COUNT_BEFORE_TRUNCATION = 8;
-
-    /**
-     * The intent spacing on JSON based responses.
-     */
-    public static final int INDENT_SPACES = 3;
 
     /**
      * The internal server error threshold defined by the HTTP protocol.
@@ -201,9 +195,9 @@ public class GraphServiceException extends ClientException {
         }
         if (verbose && error != null && error.rawObject != null) {
             try {
-                final JSONObject jsonObject = new JSONObject(error.rawObject.toString());
-                sb.append(jsonObject.toString(INDENT_SPACES)).append(NEW_LINE);
-            } catch (final JSONException ignored) {
+                final Gson gson = new GsonBuilder().setPrettyPrinting().create();
+                sb.append(gson.toJson(error.rawObject)).append(NEW_LINE);
+            } catch (final RuntimeException ignored) {
                 sb.append("[Warning: Unable to parse error message body]").append(NEW_LINE);
             }
         } else {

--- a/src/test/java/com/microsoft/graph/functional/TestBase.java
+++ b/src/test/java/com/microsoft/graph/functional/TestBase.java
@@ -1,5 +1,8 @@
 package com.microsoft.graph.functional;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
 import com.microsoft.graph.authentication.IAuthenticationProvider;
 import com.microsoft.graph.core.DefaultClientConfig;
 import com.microsoft.graph.core.IClientConfig;
@@ -7,8 +10,6 @@ import com.microsoft.graph.http.IHttpRequest;
 import com.microsoft.graph.models.extensions.IGraphServiceClient;
 import com.microsoft.graph.models.extensions.GraphServiceClient;
 import com.microsoft.graph.core.Constants;
-
-import org.json.JSONObject;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
@@ -96,7 +97,7 @@ public class TestBase {
             }
             conn.disconnect();
 
-            JSONObject res = new JSONObject(jsonString.toString());
+            JsonObject res = new GsonBuilder().create().fromJson(jsonString.toString(), JsonObject.class);
             return res.get("access_token").toString();
 
         } catch (Exception e) {


### PR DESCRIPTION
see discussion in #9.

One consequence of using gson instead of org.json:json is that I've dropped indent control on the pretty printing. The indent is 2 spaces now and is not configurable. If we want control of that value then I can put in a more verbose block of gson code. What would you like to do?