### PR TITLE
set max heap to 4g

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-org.gradle.jvmargs=-XX:MaxPermSize=512m
+org.gradle.jvmargs=-XX:MaxPermSize=512m -Xmx4g
 
 mavenRepoUrl         = https://api.bintray.com/maven/microsoftgraph/Maven/msgraph-sdk-android
 mavenGroupId         = com.microsoft.graph


### PR DESCRIPTION
Turns out that building the project needs a lot of memory (builds crashed on my laptop) so this explicitly sets the max heap. @cbales did this problem surface in your CI setup?