### PR TITLE
Ensure derived type serialization sets rawObject

### DIFF
--- a/src/test/java/com/microsoft/graph/serializer/DefaultSeralizerTests.java
+++ b/src/test/java/com/microsoft/graph/serializer/DefaultSeralizerTests.java
@@ -10,6 +10,7 @@ import com.microsoft.graph.models.extensions.FileAttachment;
 import com.microsoft.graph.models.generated.RecurrenceRangeType;
 import com.microsoft.graph.models.generated.BaseRecurrenceRange;
 import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import com.microsoft.graph.http.MockConnection;
 import com.microsoft.graph.logger.DefaultLogger;
 import com.microsoft.graph.models.extensions.Attachment;
@@ -93,5 +94,8 @@ public class DefaultSeralizerTests {
 		
 		FileAttachment fileAttachment = (FileAttachment) result;
 		assertNotNull(fileAttachment.contentBytes);
+		JsonObject o = fileAttachment.getRawObject();
+		assertNotNull(o);
+		assertEquals("#microsoft.graph.fileAttachment", o. get("@odata.type").getAsString());
 	}
 }


### PR DESCRIPTION
To fix #35.

Ensures when json is being deserialized and a derived type exists for the target class that the `rawObject` field is populated. 

Added a check to an existing test which fails on current code (but passes with this PR).