### PR TITLE
DefaultClientConfig override fix

### DIFF
--- a/src/main/java/com/microsoft/graph/core/DefaultClientConfig.java
+++ b/src/main/java/com/microsoft/graph/core/DefaultClientConfig.java
@@ -106,7 +106,7 @@ public abstract class DefaultClientConfig implements IClientConfig {
                     getAuthenticationProvider(),
                     getExecutors(),
                     getLogger());
-            logger.logDebug("Created DefaultHttpProvider");
+            getLogger().logDebug("Created DefaultHttpProvider");
         }
         return httpProvider;
     }
@@ -120,7 +120,7 @@ public abstract class DefaultClientConfig implements IClientConfig {
     public ISerializer getSerializer() {
         if (serializer == null) {
             serializer = new DefaultSerializer(getLogger());
-            logger.logDebug("Created DefaultSerializer");
+            getLogger().logDebug("Created DefaultSerializer");
         }
         return serializer;
     }
@@ -134,7 +134,7 @@ public abstract class DefaultClientConfig implements IClientConfig {
     public IExecutors getExecutors() {
         if (executors == null) {
             executors = new DefaultExecutors(getLogger());
-            logger.logDebug("Created DefaultExecutors");
+            getLogger().logDebug("Created DefaultExecutors");
         }
         return executors;
     }

--- a/src/test/java/com/microsoft/graph/core/DefaultClientConfigTests.java
+++ b/src/test/java/com/microsoft/graph/core/DefaultClientConfigTests.java
@@ -10,6 +10,8 @@ import java.util.logging.Logger;
 
 import com.microsoft.graph.authentication.IAuthenticationProvider;
 import com.microsoft.graph.authentication.MockAuthenticationProvider;
+import com.microsoft.graph.logger.DefaultLogger;
+import com.microsoft.graph.logger.ILogger;
 
 /**
  * Test cases for {@see DefaultClientConfig}
@@ -35,6 +37,24 @@ public class DefaultClientConfigTests {
         assertNotNull(mClientConfig.getHttpProvider());
         assertNotNull(mClientConfig.getAuthenticationProvider());
         assertEquals(mAuthenticationProvider, mClientConfig.getAuthenticationProvider());
+    }
+	
+    @Test
+    public void testOverrideLoggerShouldNotThrow() {
+        final ILogger logger = new DefaultLogger();
+        DefaultClientConfig config = new DefaultClientConfig() {
+
+            @Override
+            public ILogger getLogger() {
+                return logger;
+            }
+
+        };
+        config.getExecutors();
+        config.getAuthenticationProvider();
+        config.getHttpProvider();
+        config.getSerializer();
+        config.getLogger();
     }
 
 }


### PR DESCRIPTION
If `getLogger()` is overriden in `DefaultClientConfig` then the other methods throw a `NullPointerException` because the `logger` field has not been set.

PR includes test that fails on current code.