### PR TITLE
Warnings cleanup in non-gen code

### DIFF
--- a/src/main/java/com/microsoft/graph/core/BaseActionRequestBuilder.java
+++ b/src/main/java/com/microsoft/graph/core/BaseActionRequestBuilder.java
@@ -53,6 +53,7 @@ public class BaseActionRequestBuilder extends BaseRequestBuilder {
      * @param <T>  The type to which this object should be cast
      * @return The stored instance of T, otherwise null
      */
+    @SuppressWarnings("unchecked")
     protected <T> T getParameter(final String name) {
         return (T) bodyParams.get(name);
     }

--- a/src/main/java/com/microsoft/graph/core/ClientException.java
+++ b/src/main/java/com/microsoft/graph/core/ClientException.java
@@ -27,6 +27,8 @@ package com.microsoft.graph.core;
  */
 public class ClientException extends RuntimeException {
 
+    private static final long serialVersionUID = -1066560879567392559L;
+
     /**
      * Creates the client exception.
      * @param message The message to display.

--- a/src/main/java/com/microsoft/graph/http/BaseRequestBuilder.java
+++ b/src/main/java/com/microsoft/graph/http/BaseRequestBuilder.java
@@ -50,8 +50,6 @@ public abstract class BaseRequestBuilder implements IRequestBuilder {
      */
     private final List<Option> options = new ArrayList<>();
 
-    private final IJsonBackedObject body;
-
     /**
      * Creates the request builder.
      *
@@ -66,23 +64,6 @@ public abstract class BaseRequestBuilder implements IRequestBuilder {
     ) {
         this.requestUrl = requestUrl;
         this.client = client;
-        this.body = null;
-
-        if (options != null) {
-            this.options.addAll(options);
-        }
-    }
-
-    public BaseRequestBuilder(
-            final String requestUrl,
-            final IJsonBackedObject body,
-            final IBaseClient client,
-            final List<? extends Option> options
-    ) {
-        this.requestUrl = requestUrl;
-        this.client = client;
-        this.body = body;
-
         if (options != null) {
             this.options.addAll(options);
         }

--- a/src/main/java/com/microsoft/graph/http/GraphFatalServiceException.java
+++ b/src/main/java/com/microsoft/graph/http/GraphFatalServiceException.java
@@ -29,6 +29,8 @@ import java.util.List;
  */
 public class GraphFatalServiceException extends GraphServiceException {
 
+    private static final long serialVersionUID = -4974392424026672738L;
+
     /**
      * Create a fatal Graph service exception.
      * @param method The method that caused the exception.

--- a/src/main/java/com/microsoft/graph/http/GraphServiceException.java
+++ b/src/main/java/com/microsoft/graph/http/GraphServiceException.java
@@ -42,6 +42,8 @@ import com.microsoft.graph.serializer.ISerializer;
  */
 public class GraphServiceException extends ClientException {
 
+    private static final long serialVersionUID = -7416427229421064119L;
+
     /**
      * New line delimiter.
      */

--- a/src/main/java/com/microsoft/graph/logger/DefaultLogger.java
+++ b/src/main/java/com/microsoft/graph/logger/DefaultLogger.java
@@ -22,7 +22,6 @@
 
 package com.microsoft.graph.logger;
 
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**

--- a/src/main/java/com/microsoft/graph/serializer/AdditionalDataManager.java
+++ b/src/main/java/com/microsoft/graph/serializer/AdditionalDataManager.java
@@ -35,6 +35,8 @@ import java.util.Set;
 
 public class AdditionalDataManager extends HashMap<String, JsonElement> {
 
+    private static final long serialVersionUID = 8641634955796941429L;
+    
     private final transient IJsonBackedObject jsonBackedObject;
 
     public AdditionalDataManager(IJsonBackedObject jsonBackedObject) {

--- a/src/main/java/com/microsoft/graph/serializer/DefaultSerializer.java
+++ b/src/main/java/com/microsoft/graph/serializer/DefaultSerializer.java
@@ -31,6 +31,7 @@ import com.microsoft.graph.logger.ILogger;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Map.Entry;
 
 /**
  * The default serializer implementation for the SDK.
@@ -151,8 +152,9 @@ public class DefaultSerializer implements ISerializer {
 				
 				// If the object is a HashMap, iterate through its children
 				if (fieldObject instanceof HashMap) {
-					HashMap<String, Object> serializableChildren = (HashMap<String, Object>) fieldObject;
-					Iterator it = serializableChildren.entrySet().iterator();
+					@SuppressWarnings("unchecked")
+                    HashMap<String, Object> serializableChildren = (HashMap<String, Object>) fieldObject;
+					Iterator<Entry<String, Object>> it = serializableChildren.entrySet().iterator();
 					
 					while (it.hasNext()) {
 						HashMap.Entry<String, Object> pair = (HashMap.Entry<String, Object>)it.next();
@@ -222,7 +224,7 @@ public class DefaultSerializer implements ISerializer {
      * @param parentClass The parent class the derived class should inherit from
      * @return The derived class if found, or null if not applicable
      */
-    private Class getDerivedClass(JsonObject jsonObject, Class parentClass) {
+    private Class<?> getDerivedClass(JsonObject jsonObject, Class<?> parentClass) {
     	//Identify the odata.type information if provided
         if (jsonObject.get("@odata.type") != null) {
         	String odataType = jsonObject.get("@odata.type").getAsString();
@@ -231,7 +233,7 @@ public class DefaultSerializer implements ISerializer {
         	derivedType = "com.microsoft.graph.models.extensions." + derivedType; //Add full package path
         	
         	try {
-        		Class derivedClass = Class.forName(derivedType);
+        		Class<?> derivedClass = Class.forName(derivedType);
         		//Check that the derived class inherits from the given parent class
         		if (parentClass.isAssignableFrom(derivedClass)) {
         			return derivedClass;

--- a/src/main/java/com/microsoft/graph/serializer/GsonFactory.java
+++ b/src/main/java/com/microsoft/graph/serializer/GsonFactory.java
@@ -162,9 +162,9 @@ final class GsonFactory {
             }
         };
 
-        final JsonSerializer<EnumSet> enumSetJsonSerializer = new JsonSerializer<EnumSet>() {
+        final JsonSerializer<EnumSet<?>> enumSetJsonSerializer = new JsonSerializer<EnumSet<?>>() {
             @Override
-            public JsonElement serialize(final EnumSet src,
+            public JsonElement serialize(final EnumSet<?> src,
                                          final Type typeOfSrc,
                                          final JsonSerializationContext context) {
                 if (src == null || src.isEmpty()) {
@@ -175,9 +175,9 @@ final class GsonFactory {
             }
         };
 
-        final JsonDeserializer<EnumSet> enumSetJsonDeserializer = new JsonDeserializer<EnumSet>() {
+        final JsonDeserializer<EnumSet<?>> enumSetJsonDeserializer = new JsonDeserializer<EnumSet<?>>() {
             @Override
-            public EnumSet deserialize(final JsonElement json,
+            public EnumSet<?> deserialize(final JsonElement json,
                                         final Type typeOfT,
                                         final JsonDeserializationContext context) throws JsonParseException {
                 if (json == null) {


### PR DESCRIPTION
Did a quick review of non-generated code and addressed some warnings offered by Eclipse:

* added `SuppressWarning` annotations
* added `serialVersionUID` to extensions of concrete classes (like `Exception`, `HashMap`)
* remove unreferenced code in `BaseRequestBuilder`
* fixed raw type usage in `DefaultSerializer` and `GsonFactory` (not addressed by #41)