### PR TITLE
improve SynchronousExecutor so recurses safely

### DIFF
--- a/src/main/java/com/microsoft/graph/concurrency/DefaultExecutors.java
+++ b/src/main/java/com/microsoft/graph/concurrency/DefaultExecutors.java
@@ -55,7 +55,7 @@ public class DefaultExecutors implements IExecutors {
     public DefaultExecutors(final ILogger logger) {
     	this.logger = logger;
         backgroundExecutor = (ThreadPoolExecutor)Executors.newCachedThreadPool();
-        foregroundExecutor = new SynchronousExecutor();
+        foregroundExecutor = SynchronousExecutor.instance();
     }
 
     /**

--- a/src/main/java/com/microsoft/graph/concurrency/SynchronousExecutor.java
+++ b/src/main/java/com/microsoft/graph/concurrency/SynchronousExecutor.java
@@ -22,34 +22,109 @@
 
 package com.microsoft.graph.concurrency;
 
+import java.util.LinkedList;
+import java.util.Queue;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * An executor that runs only on the main thread of an Android application.
+ * An {@link Executor} that runs only on the current thread and queues tasks to
+ * ensure stack overflow does not occur.
  */
-public class SynchronousExecutor implements Executor {
+public final class SynchronousExecutor implements Executor {
 
-    /**
-     * The current number of synchronously executing actions.
-     */
-    private AtomicInteger activeCount = new AtomicInteger(0);
+    private static final SynchronousExecutor INSTANCE = new SynchronousExecutor();
 
-    /**
-     * Executes the given Runnable task.
-     * @param runnable The task to run on the main thread.
-     */
-    @Override public void execute(final Runnable runnable) {
-    	activeCount.incrementAndGet();
-    	runnable.run();
-    	activeCount.decrementAndGet();
+    public static SynchronousExecutor instance() {
+        return INSTANCE;
     }
 
     /**
-     * Get the account number of executing actions.
-     * @return The count.
+     * The current number of synchronously executing actions across all threads.
+     */
+    private final AtomicInteger activeCount = new AtomicInteger(0);
+
+    private final ThreadLocal<Tasks> tasks;
+
+    private SynchronousExecutor() {
+        this.tasks = new ThreadLocal<Tasks>() {
+            @Override
+            protected Tasks initialValue() {
+                return new Tasks();
+            }
+        };
+    }
+
+    @Override
+    public void execute(Runnable runnable) {
+        tasks.get().add(runnable);
+    }
+
+    /**
+     * Returns the current number of executing actions across all threads.
+     * 
+     * @return the current number of executing actions across all threads
      */
     public int getActiveCount() {
         return activeCount.get();
     }
+
+    private final class Tasks {
+
+        private final Queue<Runnable> queue;
+        private boolean draining;
+
+        Tasks() {
+            // as we expect the queue to be recreated frequently we choose a
+            // low allocation cost implementation of Queue
+            queue = new LinkedList<Runnable>();
+        }
+
+        void add(Runnable runnable) {
+            activeCount.incrementAndGet();
+            queue.add(runnable);
+            drain();
+        }
+
+        private void drain() {
+            if (draining) {
+                // reentrancy detected
+                return;
+            } else {
+                draining = true;
+                try {
+                    Runnable r;
+                    while ((r = queue.poll()) != null) {
+                        try {
+                            r.run();
+                        } finally {
+                            activeCount.decrementAndGet();
+                        }
+                    }
+                } catch (Throwable e) {
+                    // clear the queue and reduce the activeCount
+                    while (queue.poll() != null) {
+                        activeCount.decrementAndGet();
+                    }
+                    // is not a checked exception so must be an Error or RuntimeException
+                    if (e instanceof RuntimeException) {
+                        throw (RuntimeException) e;
+                    } else {
+                        throw (Error) e;
+                    }
+                } finally {
+                    // clear the ThreadLocal value for this thread
+                    // so that memory leak detectors don't complain
+                    // on application shutdown. This is particularly
+                    // relevant for application servers that use
+                    // container-wide thread pools like Tomcat or 
+                    // JEE implementations.
+                    tasks.remove();
+                    draining = false;
+                }
+            }
+        }
+
+    };
+
 }

--- a/src/test/java/com/microsoft/graph/concurrency/SynchronousExecutorTests.java
+++ b/src/test/java/com/microsoft/graph/concurrency/SynchronousExecutorTests.java
@@ -1,21 +1,31 @@
 package com.microsoft.graph.concurrency;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
+import org.junit.Assert;
+import org.junit.FixMethodOrder;
 import org.junit.Test;
+import org.junit.runners.MethodSorters;
 
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class SynchronousExecutorTests {
 
-	@Test
-	public void testExecute() throws Exception {
+    @Test
+    public void testExecute() throws Exception {
         final AtomicBoolean success = new AtomicBoolean(false);
         final CountDownLatch latch = new CountDownLatch(1);
-        SynchronousExecutor synchronousExecutor = new SynchronousExecutor();
+        SynchronousExecutor synchronousExecutor = SynchronousExecutor.instance();
         synchronousExecutor.execute(new Runnable() {
             @Override
             public void run() {
@@ -27,6 +37,148 @@ public class SynchronousExecutorTests {
         assertTrue(latch.await(20, TimeUnit.SECONDS));
         assertTrue(success.get());
         assertEquals(0, synchronousExecutor.getActiveCount());
+    }
+
+    @Test(timeout = 20000)
+    public void testManyReentrantCalls() {
+        final SynchronousExecutor executor = SynchronousExecutor.instance();
+        // choose a number whose size is greater than the stack call count that would
+        // incur a StackOverflowException
+        final AtomicInteger count = new AtomicInteger(100000);
+        final AtomicReference<Runnable> runnable = new AtomicReference<Runnable>();
+        runnable.set(new Runnable() {
+            @Override
+            public void run() {
+                if (count.decrementAndGet() != 0) {
+                    executor.execute(runnable.get());
+                }
+            }
+        });
+        executor.execute(runnable.get());
+        assertEquals(0, count.get());
+        assertEquals(0, executor.getActiveCount());
+    }
+
+    @Test
+    public void testMultipleTasksWhenRemoveOnEmptyIsTrue() {
+        final SynchronousExecutor executor = SynchronousExecutor.instance();
+        final AtomicInteger count = new AtomicInteger();
+        Runnable r = new Runnable() {
+            @Override
+            public void run() {
+                count.incrementAndGet();
+            }
+        };
+        executor.execute(r);
+        executor.execute(r);
+        assertEquals(2, count.get());
+        assertEquals(0, executor.getActiveCount());
+    }
+
+    @Test
+    public void testRunnableThatThrowsRuntimeException() {
+        final SynchronousExecutor executor = SynchronousExecutor.instance();
+        final RuntimeException exception = new RuntimeException();
+        try {
+            executor.execute(new Runnable() {
+                @Override
+                public void run() {
+                    throw exception;
+                }
+            });
+        } catch (RuntimeException e) {
+            assertTrue(exception == e);
+        }
+        assertEquals(0, executor.getActiveCount());
+    }
+
+    @Test
+    public void testRunnableThatThrowsError() {
+        final SynchronousExecutor executor = SynchronousExecutor.instance();
+        final Error error = new StackOverflowError();
+        try {
+            executor.execute(new Runnable() {
+                @Override
+                public void run() {
+                    throw error;
+                }
+            });
+        } catch (Throwable e) {
+            assertTrue(error == e);
+        }
+        assertEquals(0, executor.getActiveCount());
+    }
+
+    @Test
+    public void testActiveCount() {
+        final SynchronousExecutor executor = SynchronousExecutor.instance();
+        executor.execute(new Runnable() {
+            @Override
+            public void run() {
+                assertEquals(1, executor.getActiveCount());
+            }
+        });
+        assertEquals(0, executor.getActiveCount());
+    }
+
+    @Test
+    public void testQueueIsClearedWhenRunnableThrows() {
+        final SynchronousExecutor executor = SynchronousExecutor.instance();
+        final AtomicBoolean secondTaskCalled = new AtomicBoolean();
+        try {
+            executor.execute(new Runnable() {
+                @Override
+                public void run() {
+                    executor.execute(new Runnable() {
+
+                        @Override
+                        public void run() {
+                            secondTaskCalled.set(true);
+                        }
+                    });
+                    throw new RuntimeException();
+                }
+            });
+            Assert.fail("should have thrown");
+        } catch (RuntimeException e) {
+            // expected
+        }
+        assertFalse(secondTaskCalled.get());
+        // the next time the executor gets called the second task should not be queued
+        // up still
+        executor.execute(new Runnable() {
+            @Override
+            public void run() {
+                // do nothing
+            }
+        });
+        assertFalse(secondTaskCalled.get());
+    }
+
+    @Test
+    public void testOrderIsPreservedWhenRentrantCallsToExecuteMade() {
+        final List<Integer> list = new ArrayList<Integer>();
+        final SynchronousExecutor executor = SynchronousExecutor.instance();
+        executor.execute(new Runnable() {
+
+            @Override
+            public void run() {
+                list.add(1);
+                executor.execute(new Runnable() {
+                    @Override
+                    public void run() {
+                        list.add(2);
+                    }
+                });
+                executor.execute(new Runnable() {
+                    @Override
+                    public void run() {
+                        list.add(3);
+                    }
+                });
+            }
+        });
+        assertEquals(Arrays.asList(1, 2, 3), list);
     }
 
 }


### PR DESCRIPTION
As discussed in #47, `SynchronousExecutor` is prone to stack overflow when the executor is called recursively. This PR fixes that by using `ThreadLocal` queues. 

Outstanding questions:

* do we want to null the `ThreadLocal` value every time the queue is emptied? This would make memory leak detectors happier (though this is not a leak of course) but would incur extra allocation costs when recursion was not happening.
* I assumed that the failure of one runnable in the queue should clear the queue (and this is tested). Make sense?

I've added a test that failed on the old code with a `StackOverflowException` and other tests for complete coverage of `SynchronousExecutor`.
