### PR TITLE
fix DefaultHttpProvider.hasHeader

### DIFF
--- a/src/main/java/com/microsoft/graph/http/DefaultHttpProvider.java
+++ b/src/main/java/com/microsoft/graph/http/DefaultHttpProvider.java
@@ -22,6 +22,7 @@
 
 package com.microsoft.graph.http;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.microsoft.graph.authentication.IAuthenticationProvider;
 import com.microsoft.graph.concurrency.ICallback;
 import com.microsoft.graph.concurrency.IExecutors;
@@ -440,13 +441,14 @@ public class DefaultHttpProvider implements IHttpProvider {
      * Searches for the given header in a list of HeaderOptions
      *
      * @param headers The list of headers to search through
-     * @param header The header name to search for
+     * @param header The header name to search for (case insensitive)
      *
      * @return true if the header has already been set
      */
-    private Boolean hasHeader(List<HeaderOption> headers, String header) {
+    @VisibleForTesting
+    static boolean hasHeader(List<HeaderOption> headers, String header) {
         for (HeaderOption option : headers) {
-            if (option.getName() == header) {
+            if (option.getName().equalsIgnoreCase(header)) {
                 return true;
             }
         }

--- a/src/test/java/com/microsoft/graph/http/DefaultHttpProviderTests.java
+++ b/src/test/java/com/microsoft/graph/http/DefaultHttpProviderTests.java
@@ -31,6 +31,7 @@ import com.microsoft.graph.core.ClientException;
 import com.microsoft.graph.core.GraphErrorCodes;
 import com.microsoft.graph.models.extensions.Drive;
 import com.microsoft.graph.models.extensions.DriveItem;
+import com.microsoft.graph.options.HeaderOption;
 import com.microsoft.graph.logger.LoggerLevel;
 import com.microsoft.graph.logger.MockLogger;
 import com.microsoft.graph.serializer.MockSerializer;
@@ -38,6 +39,7 @@ import com.microsoft.graph.serializer.MockSerializer;
 import static org.junit.Assert.*;
 
 import java.io.InputStream;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -345,6 +347,25 @@ public class DefaultHttpProviderTests {
         }
         assertEquals(codes.length, mAuthenticationProvider.getInterceptionCount());
     }
+    
+    @Test
+    public void testHasHeaderReturnsTrue() {
+        HeaderOption h = new HeaderOption("name", "value");
+        assertTrue(DefaultHttpProvider.hasHeader(Arrays.asList(h), "name"));
+    }
+    
+    @Test
+    public void testHasHeaderReturnsTrueWhenDifferentCase() {
+        HeaderOption h = new HeaderOption("name", "value");
+        assertTrue(DefaultHttpProvider.hasHeader(Arrays.asList(h), "NAME"));
+    }
+    
+    @Test
+    public void testHasHeaderReturnsFalse() {
+        HeaderOption h = new HeaderOption("name", "value");
+        assertFalse(DefaultHttpProvider.hasHeader(Arrays.asList(h), "blah"));
+    }
+    
 
     /**
      * Configures the http provider for test cases


### PR DESCRIPTION
The method `DefaultHttpProvider.hasHeader` incorrectly uses == for string equality. I've opted to use `equalsIgnoreCase` because HTTP headers are case-insensitive.
 
Includes three unit tests.