### PR TITLE
rework GraphServiceClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,10 @@ For an example of authentication in a client application, see the [MSGraph SDK A
 After you have set the correct application ID and URL, you must get a **GraphServiceClient** object to make requests against the service. The SDK stores the account information for you, but when a user signs in for the first time, it invokes the UI to get the user's account information.
 
 ```java
-IClientConfig clientConfig = 
-  DefaultClientConfig.createWithAuthenticationProvider(mAuthenticationProvider);
-
 IGraphServiceClient graphClient = 
-  GraphServiceClient.builder()
-    .fromConfig(mClientConfig)
+  GraphServiceClient
+    .builder()
+    .authenticationProvider(authenticationProvider)
     .buildClient();
 ```
 

--- a/src/main/java/com/microsoft/graph/concurrency/DefaultExecutors.java
+++ b/src/main/java/com/microsoft/graph/concurrency/DefaultExecutors.java
@@ -23,6 +23,7 @@
 package com.microsoft.graph.concurrency;
 
 import com.microsoft.graph.logger.ILogger;
+import com.google.common.annotations.VisibleForTesting;
 import com.microsoft.graph.core.ClientException;
 
 import java.util.concurrent.Executors;
@@ -137,6 +138,11 @@ public class DefaultExecutors implements IExecutors {
                 callback.failure(exception);
             }
         });
+    }
+
+    @VisibleForTesting
+    public ILogger getLogger() {
+        return logger;
     }
 
 }

--- a/src/main/java/com/microsoft/graph/core/DefaultClientConfig.java
+++ b/src/main/java/com/microsoft/graph/core/DefaultClientConfig.java
@@ -38,11 +38,6 @@ import com.microsoft.graph.serializer.ISerializer;
 public abstract class DefaultClientConfig implements IClientConfig {
 
     /**
-     * The authentication provider instance
-     */
-    private IAuthenticationProvider authenticationProvider;
-
-    /**
      * The executors instance
      */
     private IExecutors executors;
@@ -72,8 +67,12 @@ public abstract class DefaultClientConfig implements IClientConfig {
             final IAuthenticationProvider authenticationProvider
     ) {
         DefaultClientConfig config = new DefaultClientConfig() {
+
+            @Override
+            public IAuthenticationProvider getAuthenticationProvider() {
+                return authenticationProvider;
+            }
         };
-        config.authenticationProvider = authenticationProvider;
         config.getLogger()
               .logDebug(
                         "Using provided auth provider "
@@ -90,10 +89,7 @@ public abstract class DefaultClientConfig implements IClientConfig {
      * @return the authentication provider
      */
     @Override
-    public IAuthenticationProvider getAuthenticationProvider() {
-        return authenticationProvider;
-    }
-
+    public abstract IAuthenticationProvider getAuthenticationProvider();
     /**
      * Gets the HTTP provider
      *

--- a/src/main/java/com/microsoft/graph/http/DefaultHttpProvider.java
+++ b/src/main/java/com/microsoft/graph/http/DefaultHttpProvider.java
@@ -453,4 +453,19 @@ public class DefaultHttpProvider implements IHttpProvider {
         }
         return false;
     }
+
+    @VisibleForTesting
+    public ILogger getLogger() {
+        return logger;
+    }
+
+    @VisibleForTesting
+    public IExecutors getExecutors() {
+        return executors;
+    }
+
+    @VisibleForTesting
+    public IAuthenticationProvider getAuthenticationProvider() {
+        return authenticationProvider;
+    }
 }

--- a/src/main/java/com/microsoft/graph/requests/extensions/GraphServiceClient.java
+++ b/src/main/java/com/microsoft/graph/requests/extensions/GraphServiceClient.java
@@ -74,20 +74,40 @@ public class GraphServiceClient extends BaseGraphServiceClient implements IGraph
     public static Builder builder() {
         return new Builder();
     }
+    
+    public static final class Builder {
+        
+        Builder() {
+            // restrict instantiation
+        }
 
+        /**
+         * Sets the authentication provider
+         * 
+         * @param authenticationProvider
+         *            the authentication provider
+         * @return a new builder that allows specification of other aspects of the GraphServiceClient
+         */
+        public Builder2 authenticationProvider(IAuthenticationProvider authenticationProvider) {
+            checkNotNull(authenticationProvider, "authenticationProvider");
+            return new Builder2(authenticationProvider);
+        }
+    }
+    
     /**
      * The builder for this GraphServiceClient
      */
-    public static final class Builder {
-
+    public static final class Builder2 {
+        
+        private final IAuthenticationProvider authenticationProvider;
         private ISerializer serializer;
         private IHttpProvider httpProvider;
-        private IAuthenticationProvider authenticationProvider;
         private IExecutors executors;
         private ILogger logger;
 
-        Builder() {
-            // ensure instantiation only from static factory method
+        
+        Builder2(IAuthenticationProvider authenticationProvider) {
+            this.authenticationProvider = authenticationProvider;
         }
 
         /**
@@ -97,7 +117,8 @@ public class GraphServiceClient extends BaseGraphServiceClient implements IGraph
          *            the serializer
          * @return the instance of this builder
          */
-        public Builder serializer(final ISerializer serializer) {
+        public Builder2 serializer(final ISerializer serializer) {
+            checkNotNull(serializer, "serializer");
             this.serializer = serializer;
             return this;
         }
@@ -109,20 +130,9 @@ public class GraphServiceClient extends BaseGraphServiceClient implements IGraph
          *            the httpProvider
          * @return the instance of this builder
          */
-        public Builder httpProvider(final IHttpProvider httpProvider) {
+        public Builder2 httpProvider(final IHttpProvider httpProvider) {
+            checkNotNull(httpProvider, "httpProvider");
             this.httpProvider = httpProvider;
-            return this;
-        }
-
-        /**
-         * Sets the authentication provider
-         * 
-         * @param authenticationProvider
-         *            the authentication provider
-         * @return the instance of this builder
-         */
-        public Builder authenticationProvider(final IAuthenticationProvider authenticationProvider) {
-            this.authenticationProvider = authenticationProvider;
             return this;
         }
 
@@ -133,7 +143,8 @@ public class GraphServiceClient extends BaseGraphServiceClient implements IGraph
          *            the executors
          * @return the instance of this builder
          */
-        public Builder executors(final IExecutors executors) {
+        public Builder2 executors(final IExecutors executors) {
+            checkNotNull(executors, "executors");
             this.executors = executors;
             return this;
         }
@@ -145,7 +156,8 @@ public class GraphServiceClient extends BaseGraphServiceClient implements IGraph
          *            the logger
          * @return the instance of this builder
          */
-        public Builder logger(final ILogger logger) {
+        public Builder2 logger(final ILogger logger) {
+            checkNotNull(logger, "logger");
             this.logger = logger;
             return this;
         }
@@ -162,11 +174,7 @@ public class GraphServiceClient extends BaseGraphServiceClient implements IGraph
 
                 @Override
                 public IAuthenticationProvider getAuthenticationProvider() {
-                    if (authenticationProvider != null) {
-                        return authenticationProvider;
-                    } else {
-                        return super.getAuthenticationProvider();
-                    }
+                    return authenticationProvider; 
                 }
 
                 @Override
@@ -209,4 +217,9 @@ public class GraphServiceClient extends BaseGraphServiceClient implements IGraph
         }
     }
     
+    private static void checkNotNull(Object o, String name) {
+        if (o==null) {
+            throw new NullPointerException(name + " cannot be null");
+        }
+    }
 }

--- a/src/main/java/com/microsoft/graph/requests/extensions/GraphServiceClient.java
+++ b/src/main/java/com/microsoft/graph/requests/extensions/GraphServiceClient.java
@@ -27,28 +27,50 @@ public class GraphServiceClient extends BaseGraphServiceClient implements IGraph
      */
     protected GraphServiceClient() {
     }
-    
+
     /**
      * Send a custom request to Graph
      * 
-     * @param url          the full URL to make a request with
-     * @param responseType the response class to deserialize the response into
+     * @param url
+     *            the full URL to make a request with
+     * @param responseType
+     *            the response class to deserialize the response into
      * @return the instance of this builder
      */
-    public CustomRequestBuilder customRequest(final String url, final Class responseType) {
-    	return new CustomRequestBuilder(getServiceRoot() + url, (IGraphServiceClient)this, null, responseType);
+    public <T> CustomRequestBuilder<T> customRequest(final String url, final Class<T> responseType) {
+        return new CustomRequestBuilder<T>(getServiceRoot() + url, (IGraphServiceClient) this, null, responseType);
     }
-    
+
     /**
      * Send a custom request to Graph
      * 
-     * @param url the full URL to make a request with
+     * @param url
+     *            the full URL to make a request with
      * @return the instance of this builder
      */
-    public CustomRequestBuilder customRequest(final String url) {
-    	return new CustomRequestBuilder(getServiceRoot() + url, (IGraphServiceClient)this, null, JsonObject.class);
+    public CustomRequestBuilder<JsonObject> customRequest(final String url) {
+        return new CustomRequestBuilder<JsonObject>(getServiceRoot() + url, (IGraphServiceClient) this, null,
+                JsonObject.class);
     }
-    
+
+    /**
+     * Returns a Graph service client using the given configuration.
+     * 
+     * @param config
+     *            the client configuration
+     * @return a Graph service client
+     */
+    public static IGraphServiceClient fromConfig(final IClientConfig config) {
+        GraphServiceClient client = new GraphServiceClient();
+        client.setAuthenticationProvider(config.getAuthenticationProvider());
+        client.setExecutors(config.getExecutors());
+        client.setHttpProvider(config.getHttpProvider());
+        client.setLogger(config.getLogger());
+        client.setSerializer(config.getSerializer());
+        client.validate();
+        return client;
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -56,95 +78,135 @@ public class GraphServiceClient extends BaseGraphServiceClient implements IGraph
     /**
      * The builder for this GraphServiceClient
      */
-    public static class Builder  {
-        
+    public static final class Builder {
+
+        private ISerializer serializer;
+        private IHttpProvider httpProvider;
+        private IAuthenticationProvider authenticationProvider;
+        private IExecutors executors;
+        private ILogger logger;
+
         Builder() {
-            // ensure instantiation only from static factory method 
+            // ensure instantiation only from static factory method
         }
 
         /**
-         * The client under construction
-         */
-        private final GraphServiceClient client = new GraphServiceClient();
-
-        /**
-         * Sets the serializer
+         * Sets the serializer.
          * 
-         * @param serializer the serializer
+         * @param serializer
+         *            the serializer
          * @return the instance of this builder
          */
         public Builder serializer(final ISerializer serializer) {
-            client.setSerializer(serializer);
+            this.serializer = serializer;
             return this;
         }
 
         /**
          * Sets the httpProvider
          * 
-         * @param httpProvider the httpProvider
+         * @param httpProvider
+         *            the httpProvider
          * @return the instance of this builder
          */
         public Builder httpProvider(final IHttpProvider httpProvider) {
-            client.setHttpProvider(httpProvider);
+            this.httpProvider = httpProvider;
             return this;
         }
 
         /**
          * Sets the authentication provider
          * 
-         * @param authenticationProvider the authentication provider
+         * @param authenticationProvider
+         *            the authentication provider
          * @return the instance of this builder
          */
         public Builder authenticationProvider(final IAuthenticationProvider authenticationProvider) {
-            client.setAuthenticationProvider(authenticationProvider);
+            this.authenticationProvider = authenticationProvider;
             return this;
         }
 
         /**
          * Sets the executors
          * 
-         * @param executors the executors
+         * @param executors
+         *            the executors
          * @return the instance of this builder
          */
         public Builder executors(final IExecutors executors) {
-            client.setExecutors(executors);
+            this.executors = executors;
             return this;
         }
 
         /**
          * Sets the logger
          * 
-         * @param logger the logger
+         * @param logger
+         *            the logger
          * @return the instance of this builder
          */
         public Builder logger(final ILogger logger) {
-            client.setLogger(logger);
+            this.logger = logger;
             return this;
         }
 
         /**
-         * Set this builder based on the client configuration
+         * Builds and returns the Graph service client.
          * 
-         * @param clientConfig the client configuration
-         * @return the instance of this builder
+         * @return the Graph service client object
+         * @throws ClientException
+         *             if there was an exception creating the client
          */
-        public Builder fromConfig(final IClientConfig clientConfig) {
-            return this.authenticationProvider(clientConfig.getAuthenticationProvider())
-                       .executors(clientConfig.getExecutors())
-                       .httpProvider(clientConfig.getHttpProvider())
-                       .logger(clientConfig.getLogger())
-                       .serializer(clientConfig.getSerializer());
-        }
+        public IGraphServiceClient buildClient() throws ClientException {
+            DefaultClientConfig config = new DefaultClientConfig() {
 
-        /**
-         * Builds and returns the GraphServiceClient
-         * 
-         * @return the GraphServiceClient object
-         * @throws ClientException if there was an exception creating the client
-         */
-        public IGraphServiceClient buildClient() throws ClientException  {
-            client.validate();
-            return client;
+                @Override
+                public IAuthenticationProvider getAuthenticationProvider() {
+                    if (authenticationProvider != null) {
+                        return authenticationProvider;
+                    } else {
+                        return super.getAuthenticationProvider();
+                    }
+                }
+
+                @Override
+                public IHttpProvider getHttpProvider() {
+                    if (httpProvider != null) {
+                        return httpProvider;
+                    } else {
+                        return super.getHttpProvider();
+                    }
+                }
+
+                @Override
+                public IExecutors getExecutors() {
+                    if (executors != null) {
+                        return executors;
+                    } else {
+                        return super.getExecutors();
+                    }
+                }
+
+                @Override
+                public ILogger getLogger() {
+                    if (logger !=null) {
+                        return logger;
+                    } else {
+                        return super.getLogger();
+                    }
+                }
+
+                @Override
+                public ISerializer getSerializer() {
+                    if (serializer != null) {
+                        return serializer;
+                    } else {
+                        return super.getSerializer();
+                    }
+                }
+            };
+            return GraphServiceClient.fromConfig(config);
         }
     }
+    
 }

--- a/src/main/java/com/microsoft/graph/serializer/DefaultSerializer.java
+++ b/src/main/java/com/microsoft/graph/serializer/DefaultSerializer.java
@@ -22,6 +22,7 @@
 
 package com.microsoft.graph.serializer;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.CaseFormat;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
@@ -251,5 +252,10 @@ public class DefaultSerializer implements ISerializer {
         }
         //If there is no defined OData type, return null
         return null;
+    }
+
+    @VisibleForTesting
+    public ILogger getLogger() {
+        return logger;
     }
 }

--- a/src/test/java/com/microsoft/graph/core/DefaultClientConfigTests.java
+++ b/src/test/java/com/microsoft/graph/core/DefaultClientConfigTests.java
@@ -49,6 +49,11 @@ public class DefaultClientConfigTests {
                 return logger;
             }
 
+            @Override
+            public IAuthenticationProvider getAuthenticationProvider() {
+                return new MockAuthenticationProvider();
+            }
+
         };
         config.getExecutors();
         config.getAuthenticationProvider();

--- a/src/test/java/com/microsoft/graph/functional/TestBase.java
+++ b/src/test/java/com/microsoft/graph/functional/TestBase.java
@@ -53,7 +53,7 @@ public class TestBase {
                 };
                 IClientConfig mClientConfig = DefaultClientConfig.createWithAuthenticationProvider(mAuthenticationProvider);
 
-                graphClient = GraphServiceClient.builder().fromConfig(mClientConfig).buildClient();
+                graphClient = GraphServiceClient.fromConfig(mClientConfig);
             }
             catch (Exception e)
             {

--- a/src/test/java/com/microsoft/graph/requests/extensions/GraphServiceClientTest.java
+++ b/src/test/java/com/microsoft/graph/requests/extensions/GraphServiceClientTest.java
@@ -1,0 +1,211 @@
+package com.microsoft.graph.requests.extensions;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+import com.microsoft.graph.authentication.IAuthenticationProvider;
+import com.microsoft.graph.concurrency.DefaultExecutors;
+import com.microsoft.graph.concurrency.ICallback;
+import com.microsoft.graph.concurrency.IExecutors;
+import com.microsoft.graph.concurrency.IProgressCallback;
+import com.microsoft.graph.core.ClientException;
+import com.microsoft.graph.core.DefaultClientConfig;
+import com.microsoft.graph.http.DefaultHttpProvider;
+import com.microsoft.graph.http.IHttpProvider;
+import com.microsoft.graph.http.IHttpRequest;
+import com.microsoft.graph.http.IStatefulResponseHandler;
+import com.microsoft.graph.logger.ILogger;
+import com.microsoft.graph.logger.LoggerLevel;
+import com.microsoft.graph.models.extensions.IGraphServiceClient;
+import com.microsoft.graph.serializer.DefaultSerializer;
+import com.microsoft.graph.serializer.ISerializer;
+
+public class GraphServiceClientTest {
+
+    @Test
+    public void testClientMethodsReturnStuff() {
+        IGraphServiceClient client = GraphServiceClient.fromConfig(new DefaultClientConfig() {
+        });
+        assertNull(client.getAuthenticationProvider());
+        assertNotNull(client.getExecutors());
+        assertNotNull(client.getHttpProvider());
+        assertNotNull(client.getLogger());
+        assertNotNull(client.getSerializer());
+    }
+
+    @Test
+    public void testOverrideOfDefaultLogger() {
+        ILogger logger = createLogger();
+        IGraphServiceClient client = GraphServiceClient.builder() //
+                .logger(logger) //
+                .buildClient();
+        assertNull(client.getAuthenticationProvider());
+        assertNotNull(client.getExecutors());
+        assertNotNull(client.getHttpProvider());
+        assertNotNull(client.getLogger());
+        assertNotNull(client.getSerializer());
+        assertEquals(logger, ((DefaultHttpProvider) client.getHttpProvider()).getLogger());
+        assertEquals(logger, ((DefaultSerializer) client.getSerializer()).getLogger());
+        assertEquals(logger, ((DefaultExecutors) client.getExecutors()).getLogger());
+        assertEquals(logger, client.getLogger());
+    }
+
+    @Test
+    public void testOverrideOfDefaultAuthenticationProvider() {
+        IAuthenticationProvider ap = new IAuthenticationProvider() {
+
+            @Override
+            public void authenticateRequest(IHttpRequest request) {
+                // do nothing
+            }
+        };
+        IGraphServiceClient client = GraphServiceClient.builder() //
+                .authenticationProvider(ap) //
+                .buildClient();
+        assertEquals(ap, client.getAuthenticationProvider());
+        assertNotNull(client.getExecutors());
+        assertNotNull(client.getHttpProvider());
+        assertNotNull(client.getLogger());
+        assertNotNull(client.getSerializer());
+        assertEquals(ap, ((DefaultHttpProvider) client.getHttpProvider()).getAuthenticationProvider());
+    }
+
+    @Test
+    public void testOverrideOfDefaultExecutors() {
+        IExecutors ex = new IExecutors() {
+
+            @Override
+            public void performOnBackground(Runnable runnable) {
+                // do nothing
+            }
+
+            @Override
+            public <Result> void performOnForeground(Result result, ICallback<Result> callback) {
+                // do nothing
+            }
+
+            @Override
+            public <Result> void performOnForeground(int progress, int progressMax,
+                    IProgressCallback<Result> callback) {
+                // do nothing
+            }
+
+            @Override
+            public <Result> void performOnForeground(ClientException exception, ICallback<Result> callback) {
+                // do nothing
+            }
+
+        };
+        IGraphServiceClient client = GraphServiceClient.builder() //
+                .executors(ex) //
+                .buildClient();
+        assertEquals(ex, client.getExecutors());
+        assertNull(client.getAuthenticationProvider());
+        assertNotNull(client.getHttpProvider());
+        assertNotNull(client.getLogger());
+        assertNotNull(client.getSerializer());
+        assertEquals(ex, ((DefaultHttpProvider) client.getHttpProvider()).getExecutors());
+    }
+
+    @Test
+    public void testOverrideOfSerializer() {
+        ISerializer serializer = new ISerializer() {
+
+            @Override
+            public <T> String serializeObject(T serializableObject) {
+                return null;
+            }
+
+            @Override
+            public <T> T deserializeObject(String inputString, Class<T> clazz,
+                    Map<String, List<String>> responseHeaders) {
+                return null;
+            }
+
+            @Override
+            public <T> T deserializeObject(String inputString, Class<T> clazz) {
+                return null;
+            }
+        };
+        IGraphServiceClient client = GraphServiceClient.builder() //
+                .serializer(serializer) //
+                .buildClient();
+        assertEquals(serializer, client.getSerializer());
+        assertNull(client.getAuthenticationProvider());
+        assertNotNull(client.getHttpProvider());
+        assertNotNull(client.getLogger());
+        assertNotNull(client.getExecutors());
+        assertEquals(serializer, ((DefaultHttpProvider) client.getHttpProvider()).getSerializer());
+    }
+
+    @Test
+    public void testOverrideOfHttpSerializer() {
+        IHttpProvider hp = new IHttpProvider() {
+
+            @Override
+            public ISerializer getSerializer() {
+                return null;
+            }
+
+            @Override
+            public <Result, BodyType> void send(IHttpRequest request, ICallback<Result> callback,
+                    Class<Result> resultClass, BodyType serializable) {
+                // do nothing
+            }
+
+            @Override
+            public <Result, BodyType> Result send(IHttpRequest request, Class<Result> resultClass,
+                    BodyType serializable) throws ClientException {
+                return null;
+            }
+
+            @Override
+            public <Result, BodyType, DeserializeType> Result send(IHttpRequest request, Class<Result> resultClass,
+                    BodyType serializable, IStatefulResponseHandler<Result, DeserializeType> handler)
+                    throws ClientException {
+                return null;
+            }
+        };
+        IGraphServiceClient client = GraphServiceClient //
+                .builder() //
+                .httpProvider(hp) //
+                .buildClient();
+        assertEquals(hp, client.getHttpProvider());
+        assertNull(client.getAuthenticationProvider());
+        assertNotNull(client.getSerializer());
+        assertNotNull(client.getLogger());
+        assertNotNull(client.getExecutors());
+    }
+
+    private static ILogger createLogger() {
+        return new ILogger() {
+
+            @Override
+            public void setLoggingLevel(LoggerLevel level) {
+                // do nothing
+            }
+
+            @Override
+            public LoggerLevel getLoggingLevel() {
+                return LoggerLevel.DEBUG;
+            }
+
+            @Override
+            public void logDebug(String message) {
+                // do nothing
+            }
+
+            @Override
+            public void logError(String message, Throwable throwable) {
+                // do nothing
+            }
+        };
+    }
+
+}


### PR DESCRIPTION
See #40 

The crux of this PR is it supports this use of `GraphServiceClient`:

```java
client = GraphServiceClient.fromConfig(config);
```
and

```java
client = GraphServiceClient
  .builder()
  .logger(logger)
  .executors(executors)
  ...
  .buildClient();
```
It is not possible to override sensibly the behaviour of an instantiated config because it can only be overriden via inheritance.  For this reason the static factory method `fromConfig` returns a client straight away rather than allowing further builder modification.

The builder path is based on `DefaultClientConfig` and allows any of the bits below to be overriden in a sensible way. That is if I override the logger then it will be used in all the components.

*UML Dependency diagram - DefaultClientConfig*

![deps](https://user-images.githubusercontent.com/318187/36763377-cd7fcd18-1c7b-11e8-9b65-18114159bab7.png)

A quick note that there are more tweaks that could be done with `DefaultClientConfig` and the builder but I'll leave those for later PRs. 

