### PR TITLE
Enable more than 4GB for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,3 @@
 language: java
+dist: trusty
+sudo: required


### PR DESCRIPTION
These additional options in .travis.yml give 7.5GB of ram and should work now that we are on the public Travis infrastructure. They do work for me when I enable Travis on my fork.