### PR TITLE
increase gradle heap requirement to 11GB

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@
 # org.gradle.parallel=true
 
 # The size of the library demands a large amount of RAM to build. Increase as necessary if you get GC errors
-org.gradle.jvmargs=-XX:MaxPermSize=512m -Xmx4g
+org.gradle.jvmargs=-XX:MaxPermSize=512m -Xmx10g
 
 mavenRepoUrl         = https://api.bintray.com/maven/microsoftgraph/Maven/microsoft-graph
 mavenGroupId         = com.microsoft.graph

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,8 @@
 # org.gradle.parallel=true
 
 # The size of the library demands a large amount of RAM to build. Increase as necessary if you get GC errors
-org.gradle.jvmargs=-XX:MaxPermSize=512m -Xmx10g
+## linux requires 10G, OSX requires 11G
+org.gradle.jvmargs=-XX:MaxPermSize=512m -Xmx11g
 
 mavenRepoUrl         = https://api.bintray.com/maven/microsoftgraph/Maven/microsoft-graph
 mavenGroupId         = com.microsoft.graph


### PR DESCRIPTION
as per title. 10GB works for linux.

Is the memory requirement larger on Windows?