### PR TITLE
Do not add token option if token is null.

### DIFF
--- a/src/main/java/com/microsoft/graph/requests/extensions/DriveItemDeltaCollectionRequestBuilder.java
+++ b/src/main/java/com/microsoft/graph/requests/extensions/DriveItemDeltaCollectionRequestBuilder.java
@@ -33,7 +33,10 @@ public class DriveItemDeltaCollectionRequestBuilder extends BaseDriveItemDeltaCo
      * @param token the token
      */
     public DriveItemDeltaCollectionRequestBuilder(final String requestUrl, final IBaseClient client, final java.util.List<? extends Option> requestOptions, final String token) {
-        super(requestUrl, client, requestOptions, token);
+        super(requestUrl, client, requestOptions);
+        if(token != null) {
+            functionOptions.add(new FunctionOption("token", token));
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes #81 

### Changes proposed in this pull request
- Prevents addition of null token to request URL when building from a response using
BaseDriveItemDeltaCollectionRequest::buildFromResponse(BaseDriveItemDeltaCollectionResponse)
This could be done more cleanly by changing BaseDriveItemDeltaCollectionRequest or BaseDriveItemDeltaCollectionRequestBuilder, but those are generated files.
