### PR TITLE
Issue: Hashmap child annotation serialization unit test failing

### DIFF
--- a/src/test/java/com/microsoft/graph/serializer/AdditionalDataTests.java
+++ b/src/test/java/com/microsoft/graph/serializer/AdditionalDataTests.java
@@ -73,6 +73,6 @@ public class AdditionalDataTests {
 		
 		String serializedObject = serializer.serializeObject(task);
 		
-		assertEquals("{\"assignments\":{\"id\":{\"orderHint\":\"!\",\"additionalData\":\"additionalValue\"}}}", serializedObject);
+		assertEquals("{\"assignments\":{\"id\":{\"@odata.type\":\"#microsoft.graph.plannerAssignment\",\"orderHint\":\"!\",\"additionalData\":\"additionalValue\"}},\"@odata.type\":\"#microsoft.graph.plannerTask\"}", serializedObject);
 	}
 }


### PR DESCRIPTION
Fix: Changed the string against which unit testing is being done. There is a odataType string member variable in Base class, which is overriden in one of the class which is being serialized. Hence @odata.type string should also be present in the serialized string for the object.

<!-- Read me before you submit this pull request

First off, thank you for opening this pull request! We do appreciate it.

The requests and models for this client library are generated. We won't be accepting pull requests for those code files. With that said, we do appreciate
it when you open pull requests with the proposed file changes, as we'll use that to help guide us in updating our template files.

-->

<!-- Optional. Set the issues that this pull request fixes. Delete 'Fixes #' if there isn't an issue associated with this pull request. -->
Fixes #

<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request
-

<!-- Optional. Provide related links. This might be other pull requests, code files, StackOverflow posts. Delete this section if it is not used. -->
### Other links
-
