### PR TITLE
fix published artifact versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ publishing {
 
             artifactId 'microsoft-graph'
 
-            version '${mavenMajorVersion}.${mavenMinorVersion}-SNAPSHOT'
+            version "${mavenMajorVersion}.${mavenMinorVersion}.${mavenPatchVersion}${mavenArtifactSuffix}"
 
             from components.java
 
@@ -88,7 +88,7 @@ def getVersionCode() {
 }
 
 def getVersionName() {
-    return "${mavenMajorVersion}.${mavenMinorVersion}.${mavenPatchVersion}"
+    return "${mavenMajorVersion}.${mavenMinorVersion}.${mavenPatchVersion}${mavenArtifactSuffix}"
 }
 
 uploadArchives {

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,8 +25,9 @@ mavenRepoUrl         = https://api.bintray.com/maven/microsoftgraph/Maven/micros
 mavenGroupId         = com.microsoft.graph
 mavenArtifactId      = microsoft-graph
 mavenMajorVersion    = 0
-mavenMinorVersion    = 2
+mavenMinorVersion    = 4
 mavenPatchVersion    = 0
+mavenArtifactSuffix = -SNAPSHOT
 nightliesUrl         = http://dl.bintray.com/MicrosoftGraph/Maven
 
 #These values are used to run functional tests


### PR DESCRIPTION
This PR fixes  these things about publishing maven artifacts:
* the suffix (-SNAPSHOT) should be an optional part of the version and should be present in the dev branch always
* the publish section in build.gradle did not work because property substitution does not occur in single quotes. Needs double quotes.
* the publish section did not pick up the patch version

