### PR TITLE
reduce memory requirement for gradle to 2g 

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@
 
 # The size of the library demands a large amount of RAM to build. Increase as necessary if you get GC errors
 ## linux requires 10G, OSX requires 11G
-org.gradle.jvmargs=-XX:MaxPermSize=512m -Xmx11g
+org.gradle.jvmargs=-XX:MaxPermSize=512m -Xmx2g
 
 mavenRepoUrl         = https://api.bintray.com/maven/microsoftgraph/Maven/microsoft-graph
 mavenGroupId         = com.microsoft.graph


### PR DESCRIPTION
We can now drop the memory requirement to 2GB in gradle.properties for runnning the build thanks to @deepak2016 recent merged PR #125. 