### PR TITLE
Getbytes encoding fix

### DIFF
--- a/src/main/java/com/microsoft/graph/models/extensions/Multipart.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Multipart.java
@@ -81,19 +81,22 @@ public class Multipart {
 	
 	private String createPartHeader(String name, String contentType, String filename) {
         String partContent = addBoundary();
-        String partContentWithNameAndFilename = "Content-Disposition: form-data; name=\"%s\"; filename=\"%s\"" + RETURN + "Content-Type:%s" + RETURN + RETURN;
-        String partContentWithFilename = "Content-Disposition: form-data; filename=\"%s\"" + RETURN + "Content-Type:%s" + RETURN + RETURN;
-        String partContentWithNameAndContentType = "Content-Disposition: form-data; name=\"%s\"" + RETURN + "Content-Type:%s" + RETURN + RETURN;
-        String partContentWithContentType = "Content-Disposition: form-data" + RETURN + "Content-Type:%s" + RETURN + RETURN;
-        
-        if(filename != null && name != null) 
-              partContent += String.format(partContentWithNameAndFilename, name, filename, contentType);
-        else if(filename != null) 
-              partContent += String.format(partContentWithFilename, filename, contentType);
-        else if(name != null)
-              partContent += String.format(partContentWithNameAndContentType, name, contentType);
-        else 
-              partContent += String.format(partContentWithContentType, contentType);
+        if(filename != null && name != null) {
+        	String partContentWithNameAndFilename = "Content-Disposition: form-data; name=\"%s\"; filename=\"%s\"" + RETURN + "Content-Type:%s" + RETURN + RETURN;
+            partContent += String.format(partContentWithNameAndFilename, name, filename, contentType);
+        }
+        else if(filename != null) {
+        	String partContentWithFilename = "Content-Disposition: form-data; filename=\"%s\"" + RETURN + "Content-Type:%s" + RETURN + RETURN;
+            partContent += String.format(partContentWithFilename, filename, contentType);
+        }
+        else if(name != null) {
+        	String partContentWithNameAndContentType = "Content-Disposition: form-data; name=\"%s\"" + RETURN + "Content-Type:%s" + RETURN + RETURN;
+            partContent += String.format(partContentWithNameAndContentType, name, contentType);
+        }
+        else {
+        	String partContentWithContentType = "Content-Disposition: form-data" + RETURN + "Content-Type:%s" + RETURN + RETURN;
+            partContent += String.format(partContentWithContentType, contentType);
+        }
         
         return partContent;
 	}
@@ -145,7 +148,6 @@ public class Multipart {
         writePartData(partContent, byteArray);
 	}
 
-	
 	/**
 	 * Add a part to the multipart body
 	 * @param name The name of the part

--- a/src/main/java/com/microsoft/graph/models/extensions/Multipart.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Multipart.java
@@ -112,10 +112,10 @@ public class Multipart {
 	 */
 	public static String createContentHeaderValue(String contentValue, Map<String, String> contentDispParameter) {
 		String contentHeaderValue = contentValue;
-		
+
 		if(contentDispParameter != null) {
 			for(Map.Entry<String,String> entry : contentDispParameter.entrySet())
-	            contentHeaderValue += ";" + entry.getKey() + "=\"" + entry.getValue() + "\"";
+				contentHeaderValue += ";" + entry.getKey() + "=\"" + entry.getValue() + "\"";
 		}
 		return contentHeaderValue;
 	}

--- a/src/main/java/com/microsoft/graph/models/extensions/Multipart.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Multipart.java
@@ -8,6 +8,7 @@ import java.math.BigInteger;
 import java.security.SecureRandom;
 import java.util.Map;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.microsoft.graph.options.HeaderOption;
 
 /**
@@ -79,26 +80,28 @@ public class Multipart {
 		out.write(returnContent.getBytes(MULTIPART_ENCODING));
 	}
 	
-	private String createPartHeader(String name, String contentType, String filename) {
-        String partContent = addBoundary();
-        if(filename != null && name != null) {
-        	String partContentWithNameAndFilename = "Content-Disposition: form-data; name=\"%s\"; filename=\"%s\"" + RETURN + "Content-Type:%s" + RETURN + RETURN;
-            partContent += String.format(partContentWithNameAndFilename, name, filename, contentType);
+	/**
+	 * Create content headers value and parameter
+	 * @param name The content header name
+	 * @param contentType The content header Content-Type
+	 * @param filename The content header filename 
+	 * @return content header value and parameter string 
+	 */
+	@VisibleForTesting String createPartHeader(String name, String contentType, String filename) {
+		StringBuilder partContent = new StringBuilder(addBoundary());
+		partContent.append("Content-Disposition: form-data");
+        if(filename != null) {
+        	if(name != null) 
+        		partContent.append("; name=\"").append(name).append("\"; filename=\"").append(filename).append("\"");
+        	else 
+        		partContent.append("; filename=\"").append(filename).append("\"");
         }
-        else if(filename != null) {
-        	String partContentWithFilename = "Content-Disposition: form-data; filename=\"%s\"" + RETURN + "Content-Type:%s" + RETURN + RETURN;
-            partContent += String.format(partContentWithFilename, filename, contentType);
-        }
-        else if(name != null) {
-        	String partContentWithNameAndContentType = "Content-Disposition: form-data; name=\"%s\"" + RETURN + "Content-Type:%s" + RETURN + RETURN;
-            partContent += String.format(partContentWithNameAndContentType, name, contentType);
-        }
-        else {
-        	String partContentWithContentType = "Content-Disposition: form-data" + RETURN + "Content-Type:%s" + RETURN + RETURN;
-            partContent += String.format(partContentWithContentType, contentType);
-        }
-        
-        return partContent;
+        else if(name != null) 
+        	partContent.append("; name=\"").append(name).append("\"");
+        if(contentType != null)
+        	partContent.append(RETURN).append("Content-Type: ").append(contentType);
+        partContent.append(RETURN).append(RETURN);
+        return partContent.toString();
 	}
 	
 	/**
@@ -123,7 +126,7 @@ public class Multipart {
 	 */
 	private String createPartHeader(Map<String, String> headers) {
         String partContent = addBoundary();
-        String defaultPartContent = "Content-Disposition: form-data;" + RETURN + "Content-Type:" + contentType + RETURN + RETURN;
+        String defaultPartContent = "Content-Disposition: form-data;" + RETURN + "Content-Type: " + contentType + RETURN + RETURN;
         
         if(headers != null) {         
               for(Map.Entry<String,String> entry : headers.entrySet())

--- a/src/test/java/com/microsoft/graph/functional/OneNoteTests.java
+++ b/src/test/java/com/microsoft/graph/functional/OneNoteTests.java
@@ -37,9 +37,12 @@ import com.microsoft.graph.options.QueryOption;
 import com.microsoft.graph.requests.extensions.INotebookCollectionPage;
 import com.microsoft.graph.requests.extensions.INotebookGetRecentNotebooksCollectionPage;
 import com.microsoft.graph.requests.extensions.IOnenotePageCollectionPage;
+import com.microsoft.graph.requests.extensions.IOnenotePageCollectionRequest;
+import com.microsoft.graph.requests.extensions.IOnenotePageCollectionRequestBuilder;
 import com.microsoft.graph.requests.extensions.IOnenoteRequestBuilder;
 import com.microsoft.graph.requests.extensions.IOnenoteSectionCollectionPage;
 import com.microsoft.graph.requests.extensions.ISectionGroupCollectionPage;
+import com.microsoft.graph.requests.extensions.OnenotePageCollectionRequest;
 
 /**
  * Tests for OneNote API functionality
@@ -476,10 +479,20 @@ public class OneNoteTests {
     	options.add(multipart.header());
 
     	// Post the multipart content
-    	OnenotePage page = orb
+    	IOnenotePageCollectionRequestBuilder pageReq = orb
     			.sections(testSection.id)
-    			.pages()
-    			.buildRequest(options)
+    			.pages();
+    	String expectedRequestUrl = "https://graph.microsoft.com/v1.0/me/onenote/sections/"+testSection.id+"/pages";
+    	assertEquals(expectedRequestUrl, pageReq.getRequestUrl());
+    	IOnenotePageCollectionRequest request = pageReq.buildRequest(options);
+    	assertNotNull(request);
+    	OnenotePageCollectionRequest pageCollectionReq = (OnenotePageCollectionRequest)request;
+    	List<HeaderOption> headeroption = pageCollectionReq.getHeaders();
+    	assertEquals("Content-Type", headeroption.get(0).getName());
+    	String expectedHeaderValue = "multipart/form-data; boundary=\""+multipart.getBoundary()+"\"";
+    	assertEquals(expectedHeaderValue, headeroption.get(0).getValue().toString());
+    	assertNotNull(multipart.content());
+    	OnenotePage page = pageReq.buildRequest(options)
     			.post(multipart.content());
     	assertNotNull(page);
     }

--- a/src/test/java/com/microsoft/graph/functional/OneNoteTests.java
+++ b/src/test/java/com/microsoft/graph/functional/OneNoteTests.java
@@ -439,7 +439,7 @@ public class OneNoteTests {
      * Test posting multipart content to a page
      */
     @Test
-    public void testMultipartHeadersMapPost(){
+    public void testMultipartPostWithHeadersMap(){
         try {
         	Multipart multipart = new Multipart();
         	

--- a/src/test/java/com/microsoft/graph/functional/OneNoteTests.java
+++ b/src/test/java/com/microsoft/graph/functional/OneNoteTests.java
@@ -10,6 +10,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -49,6 +50,7 @@ public class OneNoteTests {
     private OnenotePage testPage;
     private OnenoteSection testSection;
     private SectionGroup testSectionGroup2;
+    private final String HTML_ENCODING= "US-ASCII";
 
     @Before
     public void setUp() {
@@ -288,10 +290,10 @@ public class OneNoteTests {
 
     /**
      * Test posting a page stream to a page
-     * @throws InterruptedException
+     * @throws InterruptedException, UnsupportedEncodingException
      */
     @Test
-    public void testPostToNotebook() throws InterruptedException {
+    public void testPostToNotebook() throws InterruptedException, UnsupportedEncodingException {
         SectionGroup sectionGroupData = new SectionGroup();
         
         // Currently, there is no way to delete sections or section groups, so let's create a random one
@@ -319,7 +321,7 @@ public class OneNoteTests {
         // Test HTML content
         String content = "<html><head><title>Test Title</title></head><body>Test body</body></html>";
 
-        byte[] pageStream = content.getBytes();
+        byte[] pageStream = content.getBytes(HTML_ENCODING);
         List<Option> options = new ArrayList<Option>();
         options.add(new HeaderOption("Content-Type", "application/xhtml+xml"));
         OnenotePage page = orb

--- a/src/test/java/com/microsoft/graph/functional/OneNoteTests.java
+++ b/src/test/java/com/microsoft/graph/functional/OneNoteTests.java
@@ -439,53 +439,49 @@ public class OneNoteTests {
      * Test posting multipart content to a page
      */
     @Test
-    public void testMultipartPostWithHeadersMap(){
-        try {
-        	Multipart multipart = new Multipart();
-        	
-        	String htmlContent = "<!DOCTYPE html>\r\n" +
-                    "<html lang=\"en-US\">\r\n" +
-                    "<head>\r\n" +
-                    "<title>Test Multipart Page</title>\r\n" +
-                    "<meta name=\"created\" content=\"2001-01-01T01:01+0100\">\r\n" +
-                    "</head>\r\n" +
-                    "<body>\r\n" +
-                    "<p>\r\n" +
-                    "<img src=\"name:image\" />\r\n" +
-                    "</p>\r\n" +
-                    "<p>\r\n" +
-                    "<object data=\"name:attachment\" data-attachment=\"document.pdf\" /></p>\r\n" +
-                    "\r\n" +
-                    "</body>\r\n" +
-                    "</html>";
-        	File imgFile = new File("src/test/resources/hamilton.jpg");
-        	File pdfFile = new File("src/test/resources/document.pdf");
-        	
-        	Map<String, String> htmlHeaderMap = new HashMap<>();
-        	Map<String, String> contentDispMap = new HashMap<>();
-        	contentDispMap.put("name","Presentation" );
-        	htmlHeaderMap.put("Content-Disposition", Multipart.createContentHeaderValue("form-data", contentDispMap));
-        	htmlHeaderMap.put("Content-Type", Multipart.createContentHeaderValue("text/html", null));
-        	multipart.addPart(htmlHeaderMap, htmlContent.getBytes(HTML_ENCODING));
-        	
-        	InputStream fileStream = new FileInputStream(imgFile);
-        	multipart.addFormData("hamilton", "image/jpg", getByteArray(fileStream));
-        	multipart.addFilePart("metadata", "application/pdf", pdfFile);
-        	
-            // Add multipart request header
-            List<Option> options = new ArrayList<Option>();
-            options.add(multipart.header());
-            
-            // Post the multipart content
-            OnenotePage page = orb
-            		.sections(testSection.id)
-            		.pages()
-            		.buildRequest(options)
-            		.post(multipart.content());
-            assertNotNull(page);
-        } catch (Exception e) {
-            fail("Unable to write to output stream");
-        }
+    public void testMultipartPostWithHeadersMap() throws Exception{
+    	Multipart multipart = new Multipart();
+
+    	String htmlContent = "<!DOCTYPE html>\r\n" +
+    			"<html lang=\"en-US\">\r\n" +
+    			"<head>\r\n" +
+    			"<title>Test Multipart Page</title>\r\n" +
+    			"<meta name=\"created\" content=\"2001-01-01T01:01+0100\">\r\n" +
+    			"</head>\r\n" +
+    			"<body>\r\n" +
+    			"<p>\r\n" +
+    			"<img src=\"name:image\" />\r\n" +
+    			"</p>\r\n" +
+    			"<p>\r\n" +
+    			"<object data=\"name:attachment\" data-attachment=\"document.pdf\" /></p>\r\n" +
+    			"\r\n" +
+    			"</body>\r\n" +
+    			"</html>";
+    	File imgFile = new File("src/test/resources/hamilton.jpg");
+    	File pdfFile = new File("src/test/resources/document.pdf");
+
+    	Map<String, String> htmlHeaderMap = new HashMap<>();
+    	Map<String, String> contentDispMap = new HashMap<>();
+    	contentDispMap.put("name","Presentation" );
+    	htmlHeaderMap.put("Content-Disposition", Multipart.createContentHeaderValue("form-data", contentDispMap));
+    	htmlHeaderMap.put("Content-Type", Multipart.createContentHeaderValue("text/html", null));
+    	multipart.addPart(htmlHeaderMap, htmlContent.getBytes(HTML_ENCODING));
+
+    	InputStream fileStream = new FileInputStream(imgFile);
+    	multipart.addFormData("hamilton", "image/jpg", getByteArray(fileStream));
+    	multipart.addFilePart("metadata", "application/pdf", pdfFile);
+
+    	// Add multipart request header
+    	List<Option> options = new ArrayList<Option>();
+    	options.add(multipart.header());
+
+    	// Post the multipart content
+    	OnenotePage page = orb
+    			.sections(testSection.id)
+    			.pages()
+    			.buildRequest(options)
+    			.post(multipart.content());
+    	assertNotNull(page);
     }
 
     /**

--- a/src/test/java/com/microsoft/graph/functional/OneNoteTests.java
+++ b/src/test/java/com/microsoft/graph/functional/OneNoteTests.java
@@ -486,14 +486,16 @@ public class OneNoteTests {
     	assertEquals(expectedRequestUrl, pageReq.getRequestUrl());
     	IOnenotePageCollectionRequest request = pageReq.buildRequest(options);
     	assertNotNull(request);
+    	
     	OnenotePageCollectionRequest pageCollectionReq = (OnenotePageCollectionRequest)request;
     	List<HeaderOption> headeroption = pageCollectionReq.getHeaders();
     	assertEquals("Content-Type", headeroption.get(0).getName());
+    	
     	String expectedHeaderValue = "multipart/form-data; boundary=\""+multipart.getBoundary()+"\"";
     	assertEquals(expectedHeaderValue, headeroption.get(0).getValue().toString());
     	assertNotNull(multipart.content());
-    	OnenotePage page = pageReq.buildRequest(options)
-    			.post(multipart.content());
+    	
+    	OnenotePage page = request.post(multipart.content());
     	assertNotNull(page);
     }
 

--- a/src/test/java/com/microsoft/graph/functional/OneNoteTests.java
+++ b/src/test/java/com/microsoft/graph/functional/OneNoteTests.java
@@ -8,11 +8,14 @@ import static org.junit.Assert.fail;
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Ignore;
@@ -412,8 +415,61 @@ public class OneNoteTests {
         	File imgFile = new File("src/test/resources/hamilton.jpg");
         	File pdfFile = new File("src/test/resources/document.pdf");
         	
-        	multipart.addHtmlPart("Presentation", htmlContent);
+        	multipart.addHtmlPart("Presentation", htmlContent.getBytes(HTML_ENCODING));
         	multipart.addFilePart("hamilton", "image/jpg", imgFile);
+        	multipart.addFilePart("metadata", "application/pdf", pdfFile);
+        	
+            // Add multipart request header
+            List<Option> options = new ArrayList<Option>();
+            options.add(multipart.header());
+            
+            // Post the multipart content
+            OnenotePage page = orb
+            		.sections(testSection.id)
+            		.pages()
+            		.buildRequest(options)
+            		.post(multipart.content());
+            assertNotNull(page);
+        } catch (Exception e) {
+            fail("Unable to write to output stream");
+        }
+    }
+    
+    /**
+     * Test posting multipart content to a page
+     */
+    @Test
+    public void testMultipartHeadersMapPost(){
+        try {
+        	Multipart multipart = new Multipart();
+        	
+        	String htmlContent = "<!DOCTYPE html>\r\n" +
+                    "<html lang=\"en-US\">\r\n" +
+                    "<head>\r\n" +
+                    "<title>Test Multipart Page</title>\r\n" +
+                    "<meta name=\"created\" content=\"2001-01-01T01:01+0100\">\r\n" +
+                    "</head>\r\n" +
+                    "<body>\r\n" +
+                    "<p>\r\n" +
+                    "<img src=\"name:image\" />\r\n" +
+                    "</p>\r\n" +
+                    "<p>\r\n" +
+                    "<object data=\"name:attachment\" data-attachment=\"document.pdf\" /></p>\r\n" +
+                    "\r\n" +
+                    "</body>\r\n" +
+                    "</html>";
+        	File imgFile = new File("src/test/resources/hamilton.jpg");
+        	File pdfFile = new File("src/test/resources/document.pdf");
+        	
+        	Map<String, String> htmlHeaderMap = new HashMap<>();
+        	Map<String, String> contentDispMap = new HashMap<>();
+        	contentDispMap.put("name","Presentation" );
+        	htmlHeaderMap.put("Content-Disposition", Multipart.createContentHeaderValue("form-data", contentDispMap));
+        	htmlHeaderMap.put("Content-Type", Multipart.createContentHeaderValue("text/html", null));
+        	multipart.addPart(htmlHeaderMap, htmlContent.getBytes(HTML_ENCODING));
+        	
+        	InputStream fileStream = new FileInputStream(imgFile);
+        	multipart.addFormData("hamilton", "image/jpg", getByteArray(fileStream));
         	multipart.addFilePart("metadata", "application/pdf", pdfFile);
         	
             // Add multipart request header

--- a/src/test/java/com/microsoft/graph/http/MockConnection.java
+++ b/src/test/java/com/microsoft/graph/http/MockConnection.java
@@ -18,6 +18,7 @@ public class MockConnection implements IConnection {
     private final ITestConnectionData mData;
     private HashMap<String, String> mHeaders = new HashMap<>();
     private Boolean mFollowRedirects;
+    private final String JSON_ENCODING = "UTF-8";
 
     public MockConnection(ITestConnectionData data) {
         mData = data;
@@ -40,7 +41,7 @@ public class MockConnection implements IConnection {
 
     @Override
     public InputStream getInputStream() throws IOException {
-        return new ByteArrayInputStream(mData.getJsonResponse().getBytes());
+        return new ByteArrayInputStream(mData.getJsonResponse().getBytes(JSON_ENCODING));
     }
 
     @Override

--- a/src/test/java/com/microsoft/graph/models/extensions/MultipartTests.java
+++ b/src/test/java/com/microsoft/graph/models/extensions/MultipartTests.java
@@ -30,21 +30,21 @@ public class MultipartTests {
 	public void testCreatePartHeaderWithContenttypeFilename() {
 		String actual = multipart.createPartHeader(null, "image/jpg", "hamilton.jpg");
 		String expected = "--"+multipart.getBoundary()+"\r\nContent-Disposition: form-data; filename=\"hamilton.jpg\"\r\nContent-Type: image/jpg\r\n\r\n";
-        assertEquals(expected, actual);
+		assertEquals(expected, actual);
 	}
 	
 	@Test
 	public void testCreatePartHeaderWithNameContenttype() {
 		String actual = multipart.createPartHeader("hamilton", "image/jpg", null);
 		String expected = "--"+multipart.getBoundary()+"\r\nContent-Disposition: form-data; name=\"hamilton\"\r\nContent-Type: image/jpg\r\n\r\n";
-        assertEquals(expected, actual);
+		assertEquals(expected, actual);
 	}
 	
 	@Test
 	public void testCreatePartHeaderWithContenttype() {
 		String actual = multipart.createPartHeader(null, "image/jpg", null);
 		String expected = "--"+multipart.getBoundary()+"\r\nContent-Disposition: form-data\r\nContent-Type: image/jpg\r\n\r\n";
-        assertEquals(expected, actual);
+		assertEquals(expected, actual);
 	}
 	
 	@Test
@@ -52,27 +52,27 @@ public class MultipartTests {
 		String actual = multipart.createPartHeader(null, null, null);
 		String expected = "--"+multipart.getBoundary()+"\r\nContent-Disposition: form-data\r\n\r\n";
 		System.out.println(actual);
-        assertEquals(expected, actual);
+		assertEquals(expected, actual);
 	}
 	
 	@Test
 	public void testCreatePartHeaderWithNameFilename() {
 		String actual = multipart.createPartHeader("hamilton", null, "hamilton.jpg");
 		String expected = "--"+multipart.getBoundary()+"\r\nContent-Disposition: form-data; name=\"hamilton\"; filename=\"hamilton.jpg\"\r\n\r\n";
-        assertEquals(expected, actual);
+		assertEquals(expected, actual);
 	}
 	
 	@Test
 	public void testCreatePartHeaderWithName() {
 		String actual = multipart.createPartHeader("hamilton", null, null);
 		String expected = "--"+multipart.getBoundary()+"\r\nContent-Disposition: form-data; name=\"hamilton\"\r\n\r\n";
-        assertEquals(expected, actual);
+		assertEquals(expected, actual);
 	}
 	
 	@Test
 	public void testCreatePartHeaderWithFilename() {
 		String actual = multipart.createPartHeader(null, null, "hamilton.jpg");
 		String expected = "--"+multipart.getBoundary()+"\r\nContent-Disposition: form-data; filename=\"hamilton.jpg\"\r\n\r\n";
-        assertEquals(expected, actual);
+		assertEquals(expected, actual);
 	}
 }

--- a/src/test/java/com/microsoft/graph/models/extensions/MultipartTests.java
+++ b/src/test/java/com/microsoft/graph/models/extensions/MultipartTests.java
@@ -1,0 +1,78 @@
+package com.microsoft.graph.models.extensions;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+/**
+ * Tests for Multipart functionality
+ */
+@Ignore
+public class MultipartTests {
+	
+	private Multipart multipart;
+	
+	@Before
+    public void setUp() {
+		multipart =  new Multipart();
+	}
+	
+	@Test
+	public void testCreatePartHeaderWithNameContenttypeFilename() {
+		String actual = multipart.createPartHeader("hamilton", "image/jpg", "hamilton.jpg");
+		String expected = "--"+multipart.getBoundary()+"\r\nContent-Disposition: form-data; name=\"hamilton\"; filename=\"hamilton.jpg\"\r\nContent-Type: image/jpg\r\n\r\n";
+        assertEquals(expected, actual);
+	}
+	
+	@Test
+	public void testCreatePartHeaderWithContenttypeFilename() {
+		String actual = multipart.createPartHeader(null, "image/jpg", "hamilton.jpg");
+		String expected = "--"+multipart.getBoundary()+"\r\nContent-Disposition: form-data; filename=\"hamilton.jpg\"\r\nContent-Type: image/jpg\r\n\r\n";
+        assertEquals(expected, actual);
+	}
+	
+	@Test
+	public void testCreatePartHeaderWithNameContenttype() {
+		String actual = multipart.createPartHeader("hamilton", "image/jpg", null);
+		String expected = "--"+multipart.getBoundary()+"\r\nContent-Disposition: form-data; name=\"hamilton\"\r\nContent-Type: image/jpg\r\n\r\n";
+        assertEquals(expected, actual);
+	}
+	
+	@Test
+	public void testCreatePartHeaderWithContenttype() {
+		String actual = multipart.createPartHeader(null, "image/jpg", null);
+		String expected = "--"+multipart.getBoundary()+"\r\nContent-Disposition: form-data\r\nContent-Type: image/jpg\r\n\r\n";
+        assertEquals(expected, actual);
+	}
+	
+	@Test
+	public void testCreatePartHeader() {
+		String actual = multipart.createPartHeader(null, null, null);
+		String expected = "--"+multipart.getBoundary()+"\r\nContent-Disposition: form-data\r\n\r\n";
+		System.out.println(actual);
+        assertEquals(expected, actual);
+	}
+	
+	@Test
+	public void testCreatePartHeaderWithNameFilename() {
+		String actual = multipart.createPartHeader("hamilton", null, "hamilton.jpg");
+		String expected = "--"+multipart.getBoundary()+"\r\nContent-Disposition: form-data; name=\"hamilton\"; filename=\"hamilton.jpg\"\r\n\r\n";
+        assertEquals(expected, actual);
+	}
+	
+	@Test
+	public void testCreatePartHeaderWithName() {
+		String actual = multipart.createPartHeader("hamilton", null, null);
+		String expected = "--"+multipart.getBoundary()+"\r\nContent-Disposition: form-data; name=\"hamilton\"\r\n\r\n";
+        assertEquals(expected, actual);
+	}
+	
+	@Test
+	public void testCreatePartHeaderWithFilename() {
+		String actual = multipart.createPartHeader(null, null, "hamilton.jpg");
+		String expected = "--"+multipart.getBoundary()+"\r\nContent-Disposition: form-data; filename=\"hamilton.jpg\"\r\n\r\n";
+        assertEquals(expected, actual);
+	}
+}


### PR DESCRIPTION


<!-- Read me before you submit this pull request

First off, thank you for opening this pull request! We do appreciate it.

The requests and models for this client library are generated. We won't be accepting pull requests for those code files. With that said, we do appreciate
it when you open pull requests with the proposed file changes, as we'll use that to help guide us in updating our template files.

-->

<!-- Optional. Set the issues that this pull request fixes. Delete 'Fixes #' if there isn't an issue associated with this pull request. -->
Fixes #105 
<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request
- Set getbytes in Multipart to US-ASCII.
- Set getbytes in jsonResponse to UTF-8.
- Added getter and setter for boundary and  Content-Type of Multipart.
- Removed function addPart(String name, String contentType, String content).
- Renamed function addPart(String name, String contentType, byte[] byteArray) To addFormData(String name, String contentType, byte[] byteArray).
- Added function addPart(Map<String, String> headers, byte[] content) for user provided headers and byte content.


<!-- Optional. Provide related links. This might be other pull requests, code files, StackOverflow posts. Delete this section if it is not used. -->
### Other links
-https://tools.ietf.org/html/rfc7578
