### PR TITLE
Added task to enable signing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -251,6 +251,17 @@ signing {
 }
 tasks.withType(Sign)*.enabled = mavenCentralPublishingEnabled.toBoolean()
 
+task enableSigningArtifacts{
+	if (project.rootProject.file('local.properties').exists()) {
+        Properties properties = new Properties()
+        properties.load(project.rootProject.file('local.properties').newDataInputStream())
+        tasks.withType(Sign)*.enabled = properties.getProperty('enableSigning')
+        allprojects { ext."signing.keyId" = properties.getProperty('signing.keyId') }
+        allprojects { ext."signing.secretKeyRingFile" = properties.getProperty('signing.secretKeyRingFile') }
+        allprojects { ext."signing.password" = properties.getProperty('signing.password') }
+    }
+}
+
 def customizePom(pom) {
     pom.withXml {
         def root = asNode()


### PR DESCRIPTION

<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request
- Added enableSigningArtifacts task to enable signing of artifacts and pom file.
- Task can be invoked using "gradle enableSigningArtifacts"
