### PR TITLE
Allow custom HttpURLConnection in UrlConnection used by GraphServiceClient

### DIFF
--- a/src/main/java/com/microsoft/graph/http/DefaultHttpProvider.java
+++ b/src/main/java/com/microsoft/graph/http/DefaultHttpProvider.java
@@ -102,11 +102,28 @@ public class DefaultHttpProvider implements IHttpProvider {
                                final IAuthenticationProvider authenticationProvider,
                                final IExecutors executors,
                                final ILogger logger) {
+        this(serializer, authenticationProvider, executors, logger, new DefaultConnectionFactory());
+    }
+
+    /**
+     * Creates the DefaultHttpProvider
+     *
+     * @param serializer             the serializer
+     * @param authenticationProvider the authentication provider
+     * @param executors              the executors
+     * @param logger                 the logger for diagnostic information
+     * @param connectionFactory      the connection factory
+     */
+    public DefaultHttpProvider(final ISerializer serializer,
+                               final IAuthenticationProvider authenticationProvider,
+                               final IExecutors executors,
+                               final ILogger logger,
+                               final IConnectionFactory connectionFactory) {
         this.serializer = serializer;
         this.authenticationProvider = authenticationProvider;
         this.executors = executors;
         this.logger = logger;
-        connectionFactory = new DefaultConnectionFactory();
+        this.connectionFactory = connectionFactory;
     }
 
     /**

--- a/src/main/java/com/microsoft/graph/http/DefaultHttpURLConnectionProvider.java
+++ b/src/main/java/com/microsoft/graph/http/DefaultHttpURLConnectionProvider.java
@@ -1,0 +1,44 @@
+// ------------------------------------------------------------------------------
+// Copyright (c) 2017 Microsoft Corporation
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sub-license, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+// ------------------------------------------------------------------------------
+
+package com.microsoft.graph.http;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+
+/**
+ * Provides default HttpURLConnection
+ */
+public class DefaultHttpURLConnectionProvider implements IHttpURLConnectionProvider {
+
+    /**
+     * Creates a HttpURLConnection from an IHttpRequest
+     *
+     * @param request the request to make the connection from
+     * @return the connection object
+     * @throws IOException an exception occurs if there was a network issue creating the connection
+     */
+    @Override
+    public HttpURLConnection createFromRequest(final IHttpRequest request) throws IOException {
+        return (HttpURLConnection) request.getRequestUrl().openConnection();
+    }
+}

--- a/src/main/java/com/microsoft/graph/http/IHttpURLConnectionProvider.java
+++ b/src/main/java/com/microsoft/graph/http/IHttpURLConnectionProvider.java
@@ -1,0 +1,11 @@
+package com.microsoft.graph.http;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+
+/**
+ * Provides an HttpURLConnection
+ */
+public interface IHttpURLConnectionProvider {
+    HttpURLConnection createFromRequest(final IHttpRequest request) throws IOException;
+}

--- a/src/main/java/com/microsoft/graph/http/UrlConnection.java
+++ b/src/main/java/com/microsoft/graph/http/UrlConnection.java
@@ -56,7 +56,18 @@ public class UrlConnection implements IConnection {
      * @throws IOException an exception occurs if there was a problem creating the connection
      */
     public UrlConnection(final IHttpRequest request) throws IOException {
-        connection = (HttpURLConnection) request.getRequestUrl().openConnection();
+        this(request, new DefaultHttpURLConnectionProvider());
+    }
+
+    /**
+     * Creates a new UrlConnection
+     *
+     * @param request                   the IHttpRequest to create the connection from
+     * @param httpURLConnectionProvider provider for a HttpURLConnection
+     * @throws IOException   an exception occurs if there was a problem creating the connection
+     */
+    public UrlConnection(final IHttpRequest request, final IHttpURLConnectionProvider httpURLConnectionProvider) throws IOException {
+        connection = httpURLConnectionProvider.createFromRequest(request);
 
         for (final HeaderOption header : request.getHeaders()) {
             connection.addRequestProperty(header.getName(), header.getValue().toString());


### PR DESCRIPTION
Override constructors to allow for a custom IHttpURLConnectionProvider to be provided.
This allows for a convenient way to set the read and connect timeouts.

<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request
- Allow for a custom HttpURLConnection to be provided for GraphServiceClient. This makes it easy to set the read and connect timeouts - something that is not currently possible
