### PR TITLE
Implement configurable connection timeouts on the DefaultHttpProvider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,9 +33,3 @@ hs_err_pid*
 /target/
 /pom.xml
 local.properties
-
-# IntelliJ
-.idea
-
-# Output
-/out

--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@ hs_err_pid*
 /build/
 /bin/
 
-# Eclipse
+#Eclipse
 .project
 .classpath
 .settings

--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@ hs_err_pid*
 /build/
 /bin/
 
-#Eclipse
+# Eclipse
 .project
 .classpath
 .settings
@@ -33,3 +33,9 @@ hs_err_pid*
 /target/
 /pom.xml
 local.properties
+
+# IntelliJ
+.idea
+
+# Output
+/out

--- a/src/main/java/com/microsoft/graph/core/DefaultConnectionConfig.java
+++ b/src/main/java/com/microsoft/graph/core/DefaultConnectionConfig.java
@@ -1,0 +1,59 @@
+// ------------------------------------------------------------------------------
+// Copyright (c) 2017 Microsoft Corporation
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sub-license, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+// ------------------------------------------------------------------------------
+
+package com.microsoft.graph.core;
+
+/**
+ * The default connection configuration
+ */
+public class DefaultConnectionConfig implements IConnectionConfig {
+
+    /**
+     * Default connection read timeout
+     */
+    private static final int DEFAULT_READ_TIMEOUT_MS = 30_000;
+
+    /**
+     * Default connect timeout
+     */
+    private static final int DEFAULT_CONNECT_TIMEOUT_MS = 30_000;
+
+    /**
+     * Gets the connect timeout
+     *
+     * @return the timeout in milliseconds
+     */
+    @Override
+    public int getConnectTimeout() {
+        return DEFAULT_CONNECT_TIMEOUT_MS;
+    }
+
+    /**
+     * Gets the read timeout
+     *
+     * @return the timeout in milliseconds
+     */
+    @Override
+    public int getReadTimeout() {
+        return DEFAULT_READ_TIMEOUT_MS;
+    }
+}

--- a/src/main/java/com/microsoft/graph/core/IConnectionConfig.java
+++ b/src/main/java/com/microsoft/graph/core/IConnectionConfig.java
@@ -1,0 +1,42 @@
+// ------------------------------------------------------------------------------
+// Copyright (c) 2017 Microsoft Corporation
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sub-license, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+// ------------------------------------------------------------------------------
+
+package com.microsoft.graph.core;
+
+/**
+ * The connection configuration
+ */
+public interface IConnectionConfig {
+    /**
+     * Gets the connect timeout
+     *
+     * @return the timeout in milliseconds
+     */
+    int getConnectTimeout();
+
+    /**
+     * Gets the read timeout
+     *
+     * @return the timeout in milliseconds
+     */
+    int getReadTimeout();
+}

--- a/src/main/java/com/microsoft/graph/http/DefaultHttpProvider.java
+++ b/src/main/java/com/microsoft/graph/http/DefaultHttpProvider.java
@@ -28,6 +28,8 @@ import com.microsoft.graph.concurrency.ICallback;
 import com.microsoft.graph.concurrency.IExecutors;
 import com.microsoft.graph.concurrency.IProgressCallback;
 import com.microsoft.graph.core.ClientException;
+import com.microsoft.graph.core.DefaultConnectionConfig;
+import com.microsoft.graph.core.IConnectionConfig;
 import com.microsoft.graph.logger.ILogger;
 import com.microsoft.graph.logger.LoggerLevel;
 import com.microsoft.graph.options.HeaderOption;
@@ -86,6 +88,11 @@ public class DefaultHttpProvider implements IHttpProvider {
     private final ILogger logger;
 
     /**
+     * The connection config
+     */
+    private final IConnectionConfig connectionConfig;
+
+    /**
      * The connection factory
      */
     private IConnectionFactory connectionFactory;
@@ -102,10 +109,30 @@ public class DefaultHttpProvider implements IHttpProvider {
                                final IAuthenticationProvider authenticationProvider,
                                final IExecutors executors,
                                final ILogger logger) {
+        this(serializer, authenticationProvider, executors, logger, new DefaultConnectionConfig());
+    }
+
+    /**
+     * Creates the DefaultHttpProvider
+     *
+     * @param serializer                    the serializer
+     * @param authenticationProvider        the authentication provider
+     * @param executors                     the executors
+     * @param logger                        the logger for diagnostic information
+     * @param connectionConfig              the connection config
+
+     */
+    public DefaultHttpProvider(final ISerializer serializer,
+                               final IAuthenticationProvider authenticationProvider,
+                               final IExecutors executors,
+                               final ILogger logger,
+                               final IConnectionConfig connectionConfig
+                               ) {
         this.serializer = serializer;
         this.authenticationProvider = authenticationProvider;
         this.executors = executors;
         this.logger = logger;
+        this.connectionConfig = connectionConfig;
         connectionFactory = new DefaultConnectionFactory();
     }
 
@@ -232,6 +259,8 @@ public class DefaultHttpProvider implements IHttpProvider {
             final URL requestUrl = request.getRequestUrl();
             logger.logDebug("Starting to send request, URL " + requestUrl.toString());
             final IConnection connection = connectionFactory.createFromRequest(request);
+            connection.setConnectTimeout(connectionConfig.getConnectTimeout());
+            connection.setReadTimeout(connectionConfig.getReadTimeout());
 
             try {
                 logger.logDebug("Request Method " + request.getHttpMethod().toString());

--- a/src/main/java/com/microsoft/graph/http/IConnection.java
+++ b/src/main/java/com/microsoft/graph/http/IConnection.java
@@ -114,4 +114,18 @@ public interface IConnection {
      * @param length the length of content
      */
     void setContentLength(final int length);
+
+    /**
+     * Set the connect timeout on the connection
+     *
+     * @param connectTimeoutMilliseconds the connection timeout in milliseconds
+     */
+    void setConnectTimeout(final int connectTimeoutMilliseconds);
+
+    /**
+     * Set the read timeout on the connection
+     *
+     * @param readTimeoutMilliseconds the read timeout in milliseconds
+     */
+    void setReadTimeout(final int readTimeoutMilliseconds);
 }

--- a/src/main/java/com/microsoft/graph/http/UrlConnection.java
+++ b/src/main/java/com/microsoft/graph/http/UrlConnection.java
@@ -38,15 +38,6 @@ import java.util.Map;
  * Wrapper around HttpUrlConnection for testability
  */
 public class UrlConnection implements IConnection {
-
-    /**
-     * Default connection read timeout
-     */
-    private static final int DEFAULT_CONNECTION_READ_TIMEOUT_MS = 30_000;
-    /**
-     * Default connect timeout
-     */
-    private static final int DEFAULT_CONNECT_TIMEOUT_MS = 30_000;
     /**
      * The backing HTTP URL connection instance
      */
@@ -71,8 +62,6 @@ public class UrlConnection implements IConnection {
         }
 
         connection.setUseCaches(request.getUseCaches());
-        connection.setConnectTimeout(DEFAULT_CONNECT_TIMEOUT_MS);
-        connection.setReadTimeout(DEFAULT_CONNECTION_READ_TIMEOUT_MS);
 
         try {
             connection.setRequestMethod(request.getHttpMethod().toString());
@@ -165,6 +154,16 @@ public class UrlConnection implements IConnection {
         connection.setFixedLengthStreamingMode(length);
     }
 
+    @Override
+    public void setReadTimeout(final int readTimeoutMilliseconds) {
+        connection.setReadTimeout(readTimeoutMilliseconds);
+    }
+    
+    @Override
+    public void setConnectTimeout(final int connectTimeoutMilliseconds) {
+        connection.setConnectTimeout(connectTimeoutMilliseconds);
+    }
+    
     /**
      * Gets the response headers from an HTTP URL connection
      *

--- a/src/test/java/com/microsoft/graph/http/MockConnection.java
+++ b/src/test/java/com/microsoft/graph/http/MockConnection.java
@@ -79,7 +79,17 @@ public class MockConnection implements IConnection {
         // noop
     }
 
-	@Override
+    @Override
+    public void setConnectTimeout(int connectionTimeoutMilliseconds) {
+        // noop
+    }
+
+    @Override
+    public void setReadTimeout(int readTimeoutMilliseconds) {
+        // noop
+    }
+
+    @Override
 	public Map<String, List<String>> getResponseHeaders() {
 		Map<String, List<String>> headers = new HashMap<String, List<String>>();
 		ArrayList<String> headerValues = new ArrayList<String>();


### PR DESCRIPTION
Currently there is no way to configure the connection timeouts to custom values as they are hard coded.  This change allows connection timeouts to be configured.
