### PR TITLE
Configure connection timeout

### DIFF
--- a/src/main/java/com/microsoft/graph/core/DefaultConnectionConfig.java
+++ b/src/main/java/com/microsoft/graph/core/DefaultConnectionConfig.java
@@ -1,0 +1,77 @@
+// ------------------------------------------------------------------------------
+// Copyright (c) 2017 Microsoft Corporation
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sub-license, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+// ------------------------------------------------------------------------------
+
+package com.microsoft.graph.core;
+
+public class DefaultConnectionConfig implements IConnectionConfig{
+	
+    /**
+     * Default connect timeout
+     */
+    private static int DEFAULT_CONNECT_TIMEOUT_MS = 30_000;
+    
+    /**
+     * Default connection read timeout
+     */
+    private static int DEFAULT_READ_TIMEOUT_MS = 30_000;
+    
+    /**
+     * Gets the connect timeout
+     *
+     * @return the timeout in milliseconds
+     */
+    @Override
+    public int getConnectTimeout() {
+        return DEFAULT_CONNECT_TIMEOUT_MS;
+    }
+    
+    /**
+     * Sets the connect timeout
+     * 
+     * @param connectTimeoutValue Connect timeout in milliseconds to be set to.
+     */
+    @Override
+    public void setConnectTimeout(int connectTimeoutValue) {
+        DEFAULT_CONNECT_TIMEOUT_MS = connectTimeoutValue;
+    }
+    
+    /**
+     * Gets the read timeout
+     *
+     * @return the timeout in milliseconds
+     */
+    @Override
+    public int getReadTimeout() {
+        return DEFAULT_READ_TIMEOUT_MS;
+    }
+    
+    /**
+     * Sets the connect timeout
+     * 
+     * @param readTimeoutValue Read timeout in milliseconds to be set to.
+     */
+    @Override
+    public void setReadTimeout(int readTimeoutValue) {
+    	DEFAULT_READ_TIMEOUT_MS = readTimeoutValue;
+    }
+
+}

--- a/src/main/java/com/microsoft/graph/core/IConnectionConfig.java
+++ b/src/main/java/com/microsoft/graph/core/IConnectionConfig.java
@@ -1,0 +1,54 @@
+// ------------------------------------------------------------------------------
+// Copyright (c) 2017 Microsoft Corporation
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sub-license, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+// ------------------------------------------------------------------------------
+
+package com.microsoft.graph.core;
+
+public interface IConnectionConfig {
+
+	/**
+     * Gets the connect timeout
+     *
+     * @return the timeout in milliseconds
+     */
+    int getConnectTimeout();
+    
+    /**
+     * Sets the connect timeout
+     * 
+     * @param connectTimeoutValue Connect timeout in milliseconds to be set to.
+     */
+    void setConnectTimeout(int connectTimeoutValue);
+    
+    /**
+     * Gets the read timeout
+     *
+     * @return the timeout in milliseconds
+     */
+    int getReadTimeout();
+    
+    /**
+     * Sets the connect timeout
+     * 
+     * @param readTimeoutValue Read timeout in milliseconds to be set to.
+     */
+    void setReadTimeout(int readTimeoutValue);
+}

--- a/src/main/java/com/microsoft/graph/http/DefaultHttpProvider.java
+++ b/src/main/java/com/microsoft/graph/http/DefaultHttpProvider.java
@@ -28,6 +28,8 @@ import com.microsoft.graph.concurrency.ICallback;
 import com.microsoft.graph.concurrency.IExecutors;
 import com.microsoft.graph.concurrency.IProgressCallback;
 import com.microsoft.graph.core.ClientException;
+import com.microsoft.graph.core.DefaultConnectionConfig;
+import com.microsoft.graph.core.IConnectionConfig;
 import com.microsoft.graph.logger.ILogger;
 import com.microsoft.graph.logger.LoggerLevel;
 import com.microsoft.graph.options.HeaderOption;
@@ -89,6 +91,11 @@ public class DefaultHttpProvider implements IHttpProvider {
      * The connection factory
      */
     private IConnectionFactory connectionFactory;
+    
+    /**
+     * The connection config
+     */
+    private IConnectionConfig connectionConfig;
 
     /**
      * Creates the DefaultHttpProvider
@@ -232,6 +239,11 @@ public class DefaultHttpProvider implements IHttpProvider {
             final URL requestUrl = request.getRequestUrl();
             logger.logDebug("Starting to send request, URL " + requestUrl.toString());
             final IConnection connection = connectionFactory.createFromRequest(request);
+            if(this.connectionConfig == null) {
+                this.connectionConfig = new DefaultConnectionConfig();
+            }
+            connection.setConnectTimeout(connectionConfig.getConnectTimeout());
+            connection.setReadTimeout(connectionConfig.getReadTimeout());
 
             try {
                 logger.logDebug("Request Method " + request.getHttpMethod().toString());
@@ -478,5 +490,27 @@ public class DefaultHttpProvider implements IHttpProvider {
     @VisibleForTesting
     public IAuthenticationProvider getAuthenticationProvider() {
         return authenticationProvider;
+    }
+    
+
+    /**
+     * Get connection config for read and connect timeout in requests
+     *
+     * @return Connection configuration to be used for timeout values
+     */
+    public IConnectionConfig getConnectionConfig() {
+    	if(this.connectionConfig == null) {
+    		this.connectionConfig = new DefaultConnectionConfig();
+    	}
+        return connectionConfig;
+    }
+    
+    /**
+     * Set connection config for read and connect timeout in requests
+     *
+     * @param connectionConfig Connection configuration to be used for timeout values
+     */
+    public void setConnectionConfig(IConnectionConfig connectionConfig) {
+        this.connectionConfig = connectionConfig;
     }
 }

--- a/src/main/java/com/microsoft/graph/http/IConnection.java
+++ b/src/main/java/com/microsoft/graph/http/IConnection.java
@@ -114,4 +114,18 @@ public interface IConnection {
      * @param length the length of content
      */
     void setContentLength(final int length);
+    
+    /**
+     * Set the connect timeout on the connection
+     *
+     * @param connectTimeoutMilliseconds the connection timeout in milliseconds
+     */
+    void setConnectTimeout(final int connectTimeoutMilliseconds);
+
+    /**
+     * Set the read timeout on the connection
+     *
+     * @param readTimeoutMilliseconds the read timeout in milliseconds
+     */
+    void setReadTimeout(final int readTimeoutMilliseconds);
 }

--- a/src/main/java/com/microsoft/graph/http/IHttpProvider.java
+++ b/src/main/java/com/microsoft/graph/http/IHttpProvider.java
@@ -24,6 +24,7 @@ package com.microsoft.graph.http;
 
 import com.microsoft.graph.concurrency.ICallback;
 import com.microsoft.graph.core.ClientException;
+import com.microsoft.graph.core.IConnectionConfig;
 import com.microsoft.graph.serializer.ISerializer;
 
 /**
@@ -37,6 +38,22 @@ public interface IHttpProvider {
      * @return the serializer for this provider
      */
     ISerializer getSerializer();
+    
+    /**
+     * Get connection config for read and connect timeout in requests
+     *
+     * @return Connection configuration to be used for timeout values
+     * 
+     */
+    public IConnectionConfig getConnectionConfig();
+    
+    /**
+     * Set connection config for read and connect timeout in requests
+     *
+     * @param connectionConfig Connection configuration to be used for timeout values
+     * 
+     */
+    public void setConnectionConfig(IConnectionConfig connectionConfig);
 
     /**
      * Sends the HTTP request asynchronously

--- a/src/main/java/com/microsoft/graph/http/UrlConnection.java
+++ b/src/main/java/com/microsoft/graph/http/UrlConnection.java
@@ -40,14 +40,6 @@ import java.util.Map;
 public class UrlConnection implements IConnection {
 
     /**
-     * Default connection read timeout
-     */
-    private static final int DEFAULT_CONNECTION_READ_TIMEOUT_MS = 30_000;
-    /**
-     * Default connect timeout
-     */
-    private static final int DEFAULT_CONNECT_TIMEOUT_MS = 30_000;
-    /**
      * The backing HTTP URL connection instance
      */
     private final HttpURLConnection connection;
@@ -71,8 +63,6 @@ public class UrlConnection implements IConnection {
         }
 
         connection.setUseCaches(request.getUseCaches());
-        connection.setConnectTimeout(DEFAULT_CONNECT_TIMEOUT_MS);
-        connection.setReadTimeout(DEFAULT_CONNECTION_READ_TIMEOUT_MS);
 
         try {
             connection.setRequestMethod(request.getHttpMethod().toString());
@@ -163,6 +153,16 @@ public class UrlConnection implements IConnection {
     @Override
     public void setContentLength(final int length) {
         connection.setFixedLengthStreamingMode(length);
+    }
+    
+    @Override
+    public void setReadTimeout(final int readTimeoutMilliseconds) {
+        connection.setReadTimeout(readTimeoutMilliseconds);
+    }
+
+    @Override
+    public void setConnectTimeout(final int connectTimeoutMilliseconds) {
+        connection.setConnectTimeout(connectTimeoutMilliseconds);
     }
 
     /**

--- a/src/test/java/com/microsoft/graph/http/MockConnection.java
+++ b/src/test/java/com/microsoft/graph/http/MockConnection.java
@@ -78,6 +78,16 @@ public class MockConnection implements IConnection {
     public void setContentLength(int length) {
         // noop
     }
+    
+    @Override
+    public void setConnectTimeout(int connectionTimeoutMilliseconds) {
+        // noop
+    }
+
+    @Override
+    public void setReadTimeout(int readTimeoutMilliseconds) {
+        // noop
+    }
 
 	@Override
 	public Map<String, List<String>> getResponseHeaders() {

--- a/src/test/java/com/microsoft/graph/http/MockHttpProvider.java
+++ b/src/test/java/com/microsoft/graph/http/MockHttpProvider.java
@@ -10,6 +10,8 @@ import com.microsoft.graph.concurrency.ICallback;
 import com.microsoft.graph.concurrency.IExecutors;
 import com.microsoft.graph.concurrency.MockExecutors;
 import com.microsoft.graph.core.ClientException;
+import com.microsoft.graph.core.DefaultConnectionConfig;
+import com.microsoft.graph.core.IConnectionConfig;
 import com.microsoft.graph.logger.ILogger;
 import com.microsoft.graph.logger.MockLogger;
 import com.microsoft.graph.serializer.ISerializer;
@@ -25,6 +27,7 @@ public class MockHttpProvider implements IHttpProvider {
     private final IExecutors mExecutors;
     private final ILogger mLogger;
     private IConnectionFactory mConnectionFactory;
+    private IConnectionConfig connectionConfig;
 
     @Override
     public ISerializer getSerializer() {
@@ -108,5 +111,16 @@ public class MockHttpProvider implements IHttpProvider {
 
     void setConnectionFactory(final IConnectionFactory factory) {
         mConnectionFactory = factory;
+    }
+    
+    public IConnectionConfig getConnectionConfig() {
+    	if(this.connectionConfig == null) {
+    		this.connectionConfig = new DefaultConnectionConfig();
+    	}
+    	return this.connectionConfig;
+    }
+    
+    public void setConnectionConfig(IConnectionConfig connectionConfig) {
+    	this.connectionConfig = connectionConfig;
     }
 }

--- a/src/test/java/com/microsoft/graph/requests/extensions/GraphServiceClientTest.java
+++ b/src/test/java/com/microsoft/graph/requests/extensions/GraphServiceClientTest.java
@@ -16,6 +16,8 @@ import com.microsoft.graph.concurrency.IExecutors;
 import com.microsoft.graph.concurrency.IProgressCallback;
 import com.microsoft.graph.core.ClientException;
 import com.microsoft.graph.core.DefaultClientConfig;
+import com.microsoft.graph.core.DefaultConnectionConfig;
+import com.microsoft.graph.core.IConnectionConfig;
 import com.microsoft.graph.http.DefaultHttpProvider;
 import com.microsoft.graph.http.IHttpProvider;
 import com.microsoft.graph.http.IHttpRequest;
@@ -190,6 +192,16 @@ public class GraphServiceClientTest {
                     throws ClientException {
                 return null;
             }
+
+			@Override
+			public IConnectionConfig getConnectionConfig() {
+				return null;
+			}
+
+			@Override
+			public void setConnectionConfig(IConnectionConfig connectionConfig) {
+				// do nothing
+			}
         };
         IGraphServiceClient client = GraphServiceClient //
                 .builder() //
@@ -221,6 +233,39 @@ public class GraphServiceClientTest {
     @Test(expected = NullPointerException.class)
     public void testLoggerCannotBeNull() {
         GraphServiceClient.builder().authenticationProvider(auth).logger(null);
+    }
+    
+    @Test
+    public void connectionConfigTest() {
+    	 IAuthenticationProvider ap = new IAuthenticationProvider() {
+             @Override
+             public void authenticateRequest(IHttpRequest request) {
+                 // do nothing
+             }
+         };
+         IGraphServiceClient client = GraphServiceClient.builder()
+                 .authenticationProvider(ap)
+                 .buildClient();
+         client.getHttpProvider().setConnectionConfig(new DefaultConnectionConfig());
+         assertEquals(30_000, client.getHttpProvider().getConnectionConfig().getConnectTimeout());
+         assertEquals(30_000, client.getHttpProvider().getConnectionConfig().getReadTimeout());
+    }
+    
+    @Test
+    public void connectionConfigValuesChangeTest() {
+    	 IAuthenticationProvider ap = new IAuthenticationProvider() {
+             @Override
+             public void authenticateRequest(IHttpRequest request) {
+                 // do nothing
+             }
+         };
+         IGraphServiceClient client = GraphServiceClient.builder()
+                 .authenticationProvider(ap)
+                 .buildClient();
+         client.getHttpProvider().getConnectionConfig().setConnectTimeout(20_000);
+         client.getHttpProvider().getConnectionConfig().setReadTimeout(10_000);
+         assertEquals(20_000, client.getHttpProvider().getConnectionConfig().getConnectTimeout());
+         assertEquals(10_000, client.getHttpProvider().getConnectionConfig().getReadTimeout());
     }
 
     private static ILogger createLogger() {


### PR DESCRIPTION
<!-- Read me before you submit this pull request

First off, thank you for opening this pull request! We do appreciate it.

The requests and models for this client library are generated. We won't be accepting pull requests for those code files. With that said, we do appreciate
it when you open pull requests with the proposed file changes, as we'll use that to help guide us in updating our template files.

-->

<!-- Optional. Set the issues that this pull request fixes. Delete 'Fixes #' if there isn't an issue associated with this pull request. -->
Fixes #196 

<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request
- Added DefaultConnectionConfig which implement IConnectionConfig. Any class implementing IConnectionConfig can be passed with configured timeout values.
- Added setter and getter functions for changing values timeout values in DefaultHttpProvider.


