### PR TITLE
Fix #270 NullPointerException in CoreHttpProvider

### DIFF
--- a/src/main/java/com/microsoft/graph/http/CoreHttpProvider.java
+++ b/src/main/java/com/microsoft/graph/http/CoreHttpProvider.java
@@ -268,7 +268,7 @@ public class CoreHttpProvider implements IHttpProvider {
 					.tag(RedirectOptions.class, redirectOptions)
 					.tag(RetryOptions.class, retryOptions);
 			
-			String contenttype = null;
+			String contenttype = "";
 
 			try {
 				logger.logDebug("Request Method " + request.getHttpMethod().toString());


### PR DESCRIPTION
Fixes #270

The `sendRequestInternal` method in `CoreHttpProvider` initializes the `contenttype` to null. This causes the following `NullPointerException` when there is no content type header on the request:

```text
SEVERE: Throwable detail: com.microsoft.graph.core.ClientException: Error during http request

com.microsoft.graph.core.ClientException: Error during http request

	at com.microsoft.graph.http.CoreHttpProvider.sendRequestInternal(CoreHttpProvider.java:421)
	at com.microsoft.graph.http.CoreHttpProvider.send(CoreHttpProvider.java:204)
	at com.microsoft.graph.http.CoreHttpProvider.send(CoreHttpProvider.java:184)
	at com.microsoft.graph.http.BaseRequest.send(BaseRequest.java:306)
	at com.microsoft.graph.requests.extensions.MessageSendRequest.post(MessageSendRequest.java:62)
	at com.microsoft.graph.functional.OutlookTests.testSendDraft(OutlookTests.java:132)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68)
	at com.intellij.rt.execution.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:47)
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:242)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:70)
Caused by: java.lang.NullPointerException
	at java.util.regex.Matcher.getTextLength(Matcher.java:1283)
	at java.util.regex.Matcher.reset(Matcher.java:309)
	at java.util.regex.Matcher.<init>(Matcher.java:229)
	at java.util.regex.Pattern.matcher(Pattern.java:1093)
	at okhttp3.MediaType.get(MediaType.java:53)
	at okhttp3.MediaType.parse(MediaType.java:106)
	at com.microsoft.graph.http.CoreHttpProvider$3.contentType(CoreHttpProvider.java:346)
	at okhttp3.internal.http.BridgeInterceptor.intercept(BridgeInterceptor.java:53)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:147)
	at okhttp3.internal.http.RetryAndFollowUpInterceptor.intercept(RetryAndFollowUpInterceptor.java:126)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:147)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:121)
	at com.microsoft.graph.httpcore.TelemetryHandler.intercept(TelemetryHandler.java:35)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:147)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:121)
	at com.microsoft.graph.httpcore.RedirectHandler.intercept(RedirectHandler.java:123)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:147)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:121)
	at com.microsoft.graph.httpcore.RetryHandler.intercept(RetryHandler.java:140)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:147)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:121)
	at com.microsoft.graph.httpcore.AuthenticationHandler.intercept(AuthenticationHandler.java:31)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:147)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:121)
	at okhttp3.RealCall.getResponseWithInterceptorChain(RealCall.java:254)
	at okhttp3.RealCall.execute(RealCall.java:92)
	at com.microsoft.graph.http.CoreHttpProvider.sendRequestInternal(CoreHttpProvider.java:355)
	... 27 more
```

This fix was tested using the following code:

```text
    @Test
    public void testSendDraft() {
    	TestBase testBase = new TestBase();
    	
    	//Attempt to identify the sent message via randomly generated subject
    	String draftSubject = "Draft Test Message " + Double.toString(Math.random()*1000);
    	
        User me = testBase.graphClient.users(Constants.USERNAME).buildRequest().get();
        Recipient r = new Recipient();
        EmailAddress address = new EmailAddress();
        address.address = me.mail;
        r.emailAddress = address;
        Message message = new Message();
        message.subject = draftSubject;
        ArrayList<Recipient> recipients = new ArrayList<Recipient>();
        recipients.add(r);
        message.toRecipients = recipients;
        message.isDraft = true;
        
        //Save the message as a draft
        Message newMessage = testBase.graphClient.users(Constants.USERNAME).messages().buildRequest().post(message);
    	//Send the drafted message
    	testBase.graphClient.users(Constants.USERNAME).mailFolders("Drafts").messages(newMessage.id).send().buildRequest().post();
    	
    	java.util.List<QueryOption> options = new ArrayList<QueryOption>();
    	QueryOption o = new QueryOption("$filter", "subject eq '" + draftSubject + "'");
    	options.add(o);
    	//Check that the sent message exists on the server
    	IMessageCollectionPage mcp = testBase.graphClient.users(Constants.USERNAME).messages().buildRequest(options).get();
    	assertFalse(mcp.getCurrentPage().isEmpty());
    }
```
