### PR TITLE
fixed NullpointerException in content type during post call

### DIFF
--- a/src/main/java/com/microsoft/graph/http/CoreHttpProvider.java
+++ b/src/main/java/com/microsoft/graph/http/CoreHttpProvider.java
@@ -288,6 +288,7 @@ public class CoreHttpProvider implements IHttpProvider {
 					// This ensures that the Content-Length header is properly set
 					if (request.getHttpMethod() == HttpMethod.POST) {
 						bytesToWrite = new byte[0];
+						contenttype = Constants.BINARY_CONTENT_TYPE;
 					}
 					else {
 						bytesToWrite = null;


### PR DESCRIPTION
<!-- Read me before you submit this pull request

First off, thank you for opening this pull request! We do appreciate it.

The requests and models for this client library are generated. We won't be accepting pull requests for those code files. With that said, we do appreciate
it when you open pull requests with the proposed file changes, as we'll use that to help guide us in updating our template files.

-->

<!-- Optional. Set the issues that this pull request fixes. Delete 'Fixes #' if there isn't an issue associated with this pull request. -->
Fixes #270

<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request
-During a POST request, if the body was empty, then it showed NullPointerException. 
Redefined contenttype value for this case.

<!-- Optional. Provide related links. This might be other pull requests, code files, StackOverflow posts. Delete this section if it is not used. -->
