### PR TITLE
Add yaml generation pipeline for v1.0 typings

### DIFF
--- a/.azure-pipelines/generate-v1.0-models.yml
+++ b/.azure-pipelines/generate-v1.0-models.yml
@@ -171,7 +171,7 @@ steps:
     script: |
       git push --set-upstream origin $env:branchName | Write-Host
       Write-Host "Pushed the results of the build to the $env:branchName branch." -ForegroundColor Green
-  enabled: false
+  enabled: true
 
 # Send a notification to our Graph Tooling channel to let us know that
 # that automated build failed. This won't notify on manual builds.

--- a/.azure-pipelines/generate-v1.0-models.yml
+++ b/.azure-pipelines/generate-v1.0-models.yml
@@ -1,0 +1,192 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+name: $(BuildDefinitionName)_$(SourceBranchName)_$(Date:yyyyMMdd)$(Rev:.r)
+
+trigger: none # disable triggers based on commits.
+pr: none # disable triggers based on pull requests.
+
+resources:
+  repositories:
+  - repository: msgraph-sdk-java # The name used to reference this repository in the checkout step
+    type: github
+    endpoint: microsoftgraph
+    name: microsoftgraph/msgraph-sdk-java
+    ref: dev # checkout the dev branch
+  - repository: msgraph-metadata
+    type: github
+    endpoint: microsoftgraph
+    name: microsoftgraph/msgraph-metadata
+    ref: master # 
+  pipelines:
+  - pipeline: publishMetadata # This pipeline validates and produces an metadata artifact that we use for generation.
+    source: (v1.0 - 3) msgraph-publish-cleanmetadata
+    trigger:
+      branches:
+      - master
+
+pool:
+  vmImage: windows-latest # Info about this image: [0][1]
+
+variables:
+  - group: MicrosoftGraph # Variable group, where variables not set here come from. Set in Azure DevOps
+
+steps:
+- checkout: msgraph-sdk-java
+  clean: true
+  fetchDepth: 1
+  persistCredentials: true
+- checkout: msgraph-metadata
+  clean: true
+  fetchDepth: 1
+
+- task: PowerShell@2 # Setup environment variables and make them available to all tasks. See [1] for more info.
+  displayName: 'Calculate and set pipeline variables for this job'
+  inputs:
+    targetType: inline
+    script: |
+      
+      $repoModelsDir = "$env:Build_SourcesDirectory\msgraph-sdk-java\src\main\java\com\microsoft\graph\models\generated\"
+      $repoModelsExtensionDir = "$env:Build_SourcesDirectory\msgraph-sdk-java\src\main\java\com\microsoft\graph\models\extensions\"
+      $repoRequestExtensionDir = "$env:Build_SourcesDirectory\msgraph-sdk-java\src\main\java\com\microsoft\graph\requests\extensions\"
+      Write-Host "Path to repo model directory: $repoModelsDir"
+      Write-Host "Path to repo model extension directory: $repoModelsExtensionDir"
+      Write-Host "Path to repo request directory: $repoRequestExtensionDir"
+      Write-Host "##vso[task.setvariable variable=repoModelsDir]$repoModelsDir"
+      Write-Host "##vso[task.setvariable variable=repoModelsExtensionDir]$repoModelsExtensionDir"
+      Write-Host "##vso[task.setvariable variable=repoRequestExtensionDir]$repoRequestExtensionDir"
+
+      $outputPath = Join-Path $env:Build_SourcesDirectory "output"
+      Write-Host "Path to typewriter.exe output $outputPath"
+      Write-Host "##vso[task.setvariable variable=outputPath]$outputPath"
+
+      $cleanMetadata = "https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/clean_v10_metadata/cleanMetadataWithDescriptionsv1.0.xml"
+      Write-Host "Path to clean metadata $cleanMetadata"
+      Write-Host "##vso[task.setvariable variable=cleanMetadata]$cleanMetadata"
+
+      $branchName = "v1.0/pipelinebuild/$env:Build_BuildId" # Match the spec in the GH Action
+      Write-Host "Branch path spec for the pull request will be $branchName"
+      Write-Host "##vso[task.setvariable variable=branchName]$branchName"
+
+- task: PowerShell@2
+  displayName: 'Git: checkout dev'
+  inputs:
+    targetType: inline
+    workingDirectory: '$(Build.SourcesDirectory)/msgraph-sdk-java'
+    script: |
+      git checkout dev | Write-Host
+
+- task: PowerShell@2
+  displayName: 'Git: branch from dev named with the build id: $(Build.BuildId)'
+  inputs:
+    targetType: inline
+    workingDirectory: '$(Build.SourcesDirectory)/msgraph-sdk-java'
+    script: |
+      
+      Write-Host "The new branch name will be: $env:branchName"
+      git checkout -B $env:branchName | Write-Host
+
+- task: PowerShell@2
+  displayName: 'Git: set user config'
+  inputs:
+    targetType: inline
+    workingDirectory: '$(Build.SourcesDirectory)/msgraph-sdk-java'
+    script: |
+      git config user.email "GraphTooling@service.microsoft.com"
+      git config user.name "Microsoft Graph DevX Tooling"
+
+- task: PowerShell@2
+  displayName: 'Remove generated models and requests from the repo'
+  inputs:
+    targetType: inline
+    script: |
+      Remove-Item -Recurse $env:repoModelsDir | Write-Host
+      Remove-Item -Recurse $env:repoModelsExtensionDir | Write-Host
+      Remove-Item -Recurse $env:repoRequestExtensionDir | Write-Host
+      Write-Host "Removed the existing generated files in the repo." -ForegroundColor Green
+  enabled: false # The old GUI pipeline wasn't doing this. I recall that there was a reason
+  # for this but I can't recall the reason but I think it was related to reducing number of
+  # generated files.
+
+- task: PowerShell@2
+  displayName: 'Typewriter: generate v1.0 Java files'
+  inputs:
+    targetType: filePath
+    filePath: '$(Build.SourcesDirectory)/msgraph-metadata/scripts/runTypewriter.ps1'
+    arguments: '-verbosity Info -language Java -metadata $(cleanMetadata) -output $(outputPath) -generationMode Files'
+    workingDirectory: '$(Build.SourcesDirectory)' # Set the root for a multi-repo pipeline. /s
+  enabled: true
+
+- task: PowerShell@2
+  displayName: 'Copy generated requests and models into the repo'
+  inputs:
+    targetType: inline
+    script: |
+      # Path to typewriter output
+      $modelsDirectory = Join-Path $env:outputPath "\com\microsoft\graph\models\generated\*"
+      $modelsExtensionsDirectory = Join-Path $env:outputPath "\com\microsoft\graph\models\extensions\*"
+      $requestsExtensionsDirectory = Join-Path $env:outputPath "\com\microsoft\graph\requests\extensions\*"
+
+      # models\generated - excluding Base* should not be necessary as those files shouldn't be generated. 
+      Copy-Item $modelsDirectory -Destination $env:repoModelsDir -Exclude Base*
+      Write-Host "Copied the generated models\generated files into the repo. Excluded Base* files." -ForegroundColor Green
+
+      # models\extensions
+      Copy-Item $modelsExtensionsDirectory -Destination $env:repoModelsExtensionDir
+      Write-Host "Copied the generated models\extensions files into the repo." -ForegroundColor Green
+      
+      # requests\extensions
+      Copy-Item $requestsExtensionsDirectory -Destination $env:repoRequestExtensionDir
+      Write-Host "Copied the generated requests\extensions files into the repo." -ForegroundColor Green
+
+- task: PowerShell@2
+  displayName: 'Git: stage and commit generated files'
+  env: # [2]
+    GIT_REDIRECT_STDERR: "2>&1"
+  inputs:
+    targetType: inline
+    workingDirectory: '$(Build.SourcesDirectory)/msgraph-sdk-java'
+    script: |
+      Write-Host "About to add files....." -ForegroundColor Green
+      git add . | Write-Host
+
+      if ($env:Build_Reason -eq 'Manual') # Skip CI if manually running this pipeline.
+      {
+        git commit -m "Update generated v1.0 Java models and requests with build $env:Build_BuildId [skip ci]" | Write-Host
+      }
+      else
+      {
+        git commit -m "Update generated v1.0 Java models and requests with build $env:Build_BuildId" | Write-Host
+      }
+      
+      Write-Host "Added and committed generated java files." -ForegroundColor Green
+
+- task: PowerShell@2
+  displayName: 'Git: push updates'
+  env: # [2]
+    GIT_REDIRECT_STDERR: "2>&1"
+  inputs:
+    targetType: inline
+    workingDirectory: '$(Build.SourcesDirectory)/msgraph-sdk-java'
+    script: |
+      git push --set-upstream origin $env:branchName | Write-Host
+      Write-Host "Pushed the results of the build to the $env:branchName branch." -ForegroundColor Green
+  enabled: false
+
+# Send a notification to our Graph Tooling channel to let us know that
+# that automated build failed. This won't notify on manual builds.
+
+- task: YodLabs.O365PostMessage.O365PostMessageBuild.O365PostMessageBuild@0
+  displayName: 'Graph Client Tooling pipeline fail notification'
+  inputs:
+    addressType: serviceEndpoint
+    serviceEndpointName: 'microsoftgraph pipeline status'
+    title: '$(Build.DefinitionName) failure notification'
+    text: 'This automated pipeline has failed. View the build details for further information. This is a blocking failure.'
+  condition: and(failed(), ne(variables['Build.Reason'], 'Manual')) # Only notify if the automated build failed.
+  enabled: true
+
+# References
+# [0] https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops#use-a-microsoft-hosted-agent
+# [1] https://github.com/actions/virtual-environments/blob/master/images/win/Windows2019-Readme.md
+# [2] https://github.com/actions/virtual-environments/issues/617#issuecomment-603664319

--- a/.github/workflows/create-v1.0-pull-request.yml
+++ b/.github/workflows/create-v1.0-pull-request.yml
@@ -18,6 +18,8 @@ on:
 jobs:
   # This workflow contains a single job called "create-pull-request"
   create-pull-request:
+    # GitHub Actions don't support skip ci yet like Azure Pipelines so this check will do the same. 
+    if: github.event_name == 'push' && contains(toJson(github.event.commits), '***NO_CI***') == false && contains(toJson(github.event.commits), '[ci skip]') == false && contains(toJson(github.event.commits), '[skip ci]') == false
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     # https://github.com/actions/virtual-environments/blob/master/images/linux/Ubuntu1804-README.md
@@ -32,7 +34,7 @@ jobs:
       shell: bash
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        MESSAGE_TITLE: Generated models and request builders using Typewriter
+        MESSAGE_TITLE: Generated v1.0 models and request builders using Typewriter
         MESSAGE_BODY: "This pull request was automatically created by the GitHub Action, **${{github.workflow}}**. \n\n The commit hash is _${{github.sha}}_. \n\n **Important** Check for unexpected deletions or changes in this PR. \n\n cc: @darrelmiller"
         REVIEWERS: peombwa,ddyett
         ASSIGNEDTO: MIchaelMainer


### PR DESCRIPTION
Generates models and request builders, disables CI for manual runs (so we no longer have to get notifications when creating/debugging pipelines)

- [ ] Make sure to change target branch after PR is accepted.

Used to generate https://github.com/microsoftgraph/msgraph-sdk-java/pull/352