### PR TITLE
Add second constructor to DefaultHttpProvider

### DIFF
--- a/src/main/java/com/microsoft/graph/http/DefaultHttpProvider.java
+++ b/src/main/java/com/microsoft/graph/http/DefaultHttpProvider.java
@@ -98,7 +98,7 @@ public class DefaultHttpProvider implements IHttpProvider {
     private IConnectionConfig connectionConfig;
 
     /**
-     * Creates the DefaultHttpProvider
+     * Creates the DefaultHttpProvider using a DefaultConnectionFactory.
      *
      * @param serializer             the serializer
      * @param authenticationProvider the authentication provider
@@ -109,11 +109,28 @@ public class DefaultHttpProvider implements IHttpProvider {
                                final IAuthenticationProvider authenticationProvider,
                                final IExecutors executors,
                                final ILogger logger) {
+        this(serializer, authenticationProvider, executors, logger, new DefaultConnectionFactory());
+    }
+
+    /**
+     * Creates the DefaultHttpProvider
+     *
+     * @param serializer             the serializer
+     * @param authenticationProvider the authentication provider
+     * @param executors              the executors
+     * @param logger                 the logger for diagnostic information
+     * @param connectionFactory      an IConnectionFactory to create outgoing connections
+     */
+    public DefaultHttpProvider(final ISerializer serializer,
+                               final IAuthenticationProvider authenticationProvider,
+                               final IExecutors executors,
+                               final ILogger logger,
+                               final IConnectionFactory connectionFactory) {
         this.serializer = serializer;
         this.authenticationProvider = authenticationProvider;
         this.executors = executors;
         this.logger = logger;
-        connectionFactory = new DefaultConnectionFactory();
+        this.connectionFactory = connectionFactory;
     }
 
     /**


### PR DESCRIPTION
This allows custom a ConnectionFactory to be passed in.


### Changes proposed in this pull request
DefaultHttpProvider is useful, but I need to pass in a different IConnectionFactory for my use case.

I know I could always rewrite DefaultHttpProvider to use a custom connection factory, but this might be useful to others.

#367
