### PR TITLE
Fix issue #374 driveItem.additionalDataManager().put() not working

### DIFF
--- a/src/main/java/com/microsoft/graph/serializer/DefaultSerializer.java
+++ b/src/main/java/com/microsoft/graph/serializer/DefaultSerializer.java
@@ -266,7 +266,7 @@ public class DefaultSerializer implements ISerializer {
     }
 
     private boolean fieldIsOdataTransient(Map.Entry<String, JsonElement> entry) {
-        return (entry.getKey().startsWith("@") && entry.getKey() != "@odata.type");
+        return (entry.getKey().startsWith("@") && !entry.getKey().equals("@odata.type") && !entry.getKey().equals("@microsoft.graph.conflictBehavior"));
     }
     
     /**

--- a/src/main/java/com/microsoft/graph/serializer/DefaultSerializer.java
+++ b/src/main/java/com/microsoft/graph/serializer/DefaultSerializer.java
@@ -256,17 +256,8 @@ public class DefaultSerializer implements ISerializer {
      */
     private void addAdditionalDataToJson(AdditionalDataManager additionalDataManager, JsonObject jsonNode) {
     	for (Map.Entry<String, JsonElement> entry : additionalDataManager.entrySet()) {
-            if (!fieldIsOdataTransient(entry)) {
-                jsonNode.add(
-                        entry.getKey(),
-                        entry.getValue()
-                );
-            }
+                jsonNode.add(entry.getKey(), entry.getValue());
         }
-    }
-
-    private boolean fieldIsOdataTransient(Map.Entry<String, JsonElement> entry) {
-        return (entry.getKey().startsWith("@") && !entry.getKey().equals("@odata.type") && !entry.getKey().equals("@microsoft.graph.conflictBehavior"));
     }
     
     /**

--- a/src/test/java/com/microsoft/graph/serializer/AdditionalDataTests.java
+++ b/src/test/java/com/microsoft/graph/serializer/AdditionalDataTests.java
@@ -57,19 +57,6 @@ public class AdditionalDataTests {
 	}
 	
 	@Test
-	public void testSkipTransientData() {
-		Entity entity = new Entity();
-		entity.id = "1";
-		
-		entity.additionalDataManager().put("@odata.type", new JsonPrimitive("entity"));
-		entity.additionalDataManager().put("@odata.nextLink", new JsonPrimitive("1"));
-		
-		String serializedObject = serializer.serializeObject(entity);
-		
-		assertEquals("{\"id\":\"1\",\"@odata.type\":\"entity\"}", serializedObject);
-	}
-	
-	@Test
 	public void testHashMapChildAnnotationData() {
 		PlannerTask task = new PlannerTask();
 		task.assignments = new PlannerAssignments();


### PR DESCRIPTION
<!-- Read me before you submit this pull request

First off, thank you for opening this pull request! We do appreciate it.

The requests and models for this client library are generated. We won't be accepting pull requests for those code files. With that said, we do appreciate
it when you open pull requests with the proposed file changes, as we'll use that to help guide us in updating our template files.

-->

<!-- Optional. Set the issues that this pull request fixes. Delete 'Fixes #' if there isn't an issue associated with this pull request. -->
Fixes #374 

<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request
-Code snippet:
DriveItem driveItem = new DriveItem();
driveItem.name = folder;
driveItem.folder = new Folder();
driveItem.folder.additionalDataManager().put("@microsoft.graph.conflictBehavior", new JsonPrimitive("rename"));

The additionalDataManager content will not add in request payload because of transient type.
Actual payload : {"folder":{},"name":"folder"}
Expected payload: {"folder":{},"name":"folder", "@microsoft.graph.conflictBehavior":"rename"}

In DefaultSerializer.java file, the method fieldIsOdataTransient() not considering the "@microsoft.graph.conflictBehavior" entry.
Added check for "@microsoft.graph.conflictBehavior" entry same as "@odata.type" entry.


<!-- Optional. Provide related links. This might be other pull requests, code files, StackOverflow posts. Delete this section if it is not used. -->
### Other links
-
