### PR TITLE
#317 DefaultConnectionConfig.setMaxRetries sets the maxRedirects, not…

### DIFF
--- a/src/main/java/com/microsoft/graph/core/DefaultConnectionConfig.java
+++ b/src/main/java/com/microsoft/graph/core/DefaultConnectionConfig.java
@@ -164,7 +164,7 @@ public class DefaultConnectionConfig implements IConnectionConfig{
      * @param maxRetries Max retries for a request
      */
     public void setMaxRetries(int maxRetries) {
-    	this.maxRedirects = maxRedirects;
+    	this.maxRetries = maxRetries;
     }
     
     /**


### PR DESCRIPTION
Fixes #317

### Changes proposed in this pull request
* According to #317, I think "setMaxRetries" sets a value to "maxRetries" that "getMaxRetries" retrieves.