### PR TITLE
[#396] OneDrive Chunked Upload - Chunk size is not taken into consideration in case of customized input stream

### DIFF
--- a/src/main/java/com/microsoft/graph/concurrency/ChunkedUploadProvider.java
+++ b/src/main/java/com/microsoft/graph/concurrency/ChunkedUploadProvider.java
@@ -168,10 +168,10 @@ public class ChunkedUploadProvider<UploadType> {
         byte[] buffer = new byte[chunkSize];
 
         while (this.readSoFar < this.streamSize) {
-            int read = 0;
             int buffRead = 0;
 
             while (buffRead < chunkSize) {
+                int read = 0;
                 read = this.inputStream.read(buffer, buffRead, chunkSize - buffRead);
                 if (read == -1) {
                     break;

--- a/src/main/java/com/microsoft/graph/concurrency/ChunkedUploadProvider.java
+++ b/src/main/java/com/microsoft/graph/concurrency/ChunkedUploadProvider.java
@@ -168,14 +168,19 @@ public class ChunkedUploadProvider<UploadType> {
         byte[] buffer = new byte[chunkSize];
 
         while (this.readSoFar < this.streamSize) {
-            int read = this.inputStream.read(buffer);
+            int read = 0;
+            int buffRead = 0;
 
-            if (read == -1) {
-                break;
+            while (buffRead < chunkSize) {
+                read = this.inputStream.read(buffer, buffRead, chunkSize - buffRead);
+                if (read == -1) {
+                    break;
+                }
+                buffRead += read;
             }
 
             ChunkedUploadRequest request =
-                    new ChunkedUploadRequest(this.uploadUrl, this.client, options, buffer, read,
+                    new ChunkedUploadRequest(this.uploadUrl, this.client, options, buffer, buffRead,
                             maxRetry, this.readSoFar, this.streamSize);
             ChunkedUploadResult<UploadType> result = request.upload(this.responseHandler);
 
@@ -190,7 +195,7 @@ public class ChunkedUploadProvider<UploadType> {
                 break;
             }
 
-            this.readSoFar += read;
+            this.readSoFar += buffRead;
         }
     }
     

--- a/src/main/java/com/microsoft/graph/concurrency/ChunkedUploadProvider.java
+++ b/src/main/java/com/microsoft/graph/concurrency/ChunkedUploadProvider.java
@@ -170,6 +170,7 @@ public class ChunkedUploadProvider<UploadType> {
         while (this.readSoFar < this.streamSize) {
             int buffRead = 0;
 
+            // inner loop is to work-around the case where read buffer size is limited to less than chunk size by a global setting
             while (buffRead < chunkSize) {
                 int read = 0;
                 read = this.inputStream.read(buffer, buffRead, chunkSize - buffRead);


### PR DESCRIPTION

<!-- Optional. Set the issues that this pull request fixes. Delete 'Fixes #' if there isn't an issue associated with this pull request. -->
Fixes #396 

<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request
- Continue to read from the input stream to make sure the buffer is filled with data until the chunk size is reached before executing the chunked upload request.

