### PR TITLE
Fix some OkHttp response body leaks

### DIFF
--- a/src/main/java/com/microsoft/graph/http/CoreHttpProvider.java
+++ b/src/main/java/com/microsoft/graph/http/CoreHttpProvider.java
@@ -269,6 +269,7 @@ public class CoreHttpProvider implements IHttpProvider {
 					.tag(RetryOptions.class, retryOptions);
 			
 			String contenttype = null;
+			Response response = null;
 
 			try {
 				logger.logDebug("Request Method " + request.getHttpMethod().toString());
@@ -353,7 +354,7 @@ public class CoreHttpProvider implements IHttpProvider {
 				coreHttpRequest = corehttpRequestBuilder.build();
 
 				// Call being executed
-				Response response = corehttpClient.newCall(coreHttpRequest).execute();
+				response = corehttpClient.newCall(coreHttpRequest).execute();
 
 				if (handler != null) {
 					handler.configConnection(response);
@@ -401,12 +402,13 @@ public class CoreHttpProvider implements IHttpProvider {
 					return (Result) handleBinaryStream(in);
 				}
 			} finally {
-				if (!isBinaryStreamInput && in != null) {
+				if (!isBinaryStreamInput) {
 					try{
-						in.close();
+						if (in != null) in.close();
 					}catch(IOException e) {
 						logger.logError(e.getMessage(), e);
 					}
+					if (response != null) response.close();
 				}
 			}
 		} catch (final GraphServiceException ex) {

--- a/src/main/java/com/microsoft/graph/http/GraphServiceException.java
+++ b/src/main/java/com/microsoft/graph/http/GraphServiceException.java
@@ -23,6 +23,7 @@
 package com.microsoft.graph.http;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
@@ -38,6 +39,7 @@ import com.microsoft.graph.options.HeaderOption;
 import com.microsoft.graph.serializer.ISerializer;
 
 import okhttp3.Response;
+import static okhttp3.internal.Util.closeQuietly;
 
 /**
  * An exception from the Graph service
@@ -416,8 +418,12 @@ public class GraphServiceException extends ClientException {
 
         final String responseMessage = response.message();
         String rawOutput = "{}";
-        if(response.body().byteStream() != null) {
-        	rawOutput = DefaultHttpProvider.streamToString(response.body().byteStream());
+
+        InputStream is = response.body().byteStream();
+        try {
+            rawOutput = DefaultHttpProvider.streamToString(is);
+        } finally {
+            closeQuietly(is);
         }
         GraphErrorResponse error;
         try {


### PR DESCRIPTION
Fixes #284 
Closes #333

### Changes proposed in this pull request
- OkHttp response bodies are required to be closed. See https://square.github.io/okhttp/4.x/okhttp/okhttp3/-response-body/. There are a couple of places in which this does not happen, and this pull should fix at least some of those leaks.

The first is in `CoreHttpProvider`. In the cases in which a `byteStream` is obtained from the response body, the stream is closed, which closes the body, so those are ok. However, in some other cases, the Response is used without closing it. Now, closing the Response in the finally method covers all those situations.

The second is in `GraphServiceException` which reads the response body but did not close it.

### Other links
- https://square.github.io/okhttp/4.x/okhttp/okhttp3/-response-body/
