### PR TITLE
- fixes a bug where jwts would be shown in error messages

### DIFF
--- a/src/main/java/com/microsoft/graph/http/GraphServiceException.java
+++ b/src/main/java/com/microsoft/graph/http/GraphServiceException.java
@@ -28,11 +28,11 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Collections;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.microsoft.graph.core.ClientException;
-import com.microsoft.graph.core.GraphErrorCodes;
 import com.microsoft.graph.logger.ILogger;
 import com.microsoft.graph.logger.LoggerLevel;
 import com.microsoft.graph.options.HeaderOption;
@@ -150,8 +150,16 @@ public class GraphServiceException extends ClientException {
         this.responseHeaders = responseHeaders;
         this.error = error;
         this.verbose = verbose;
+        for(String requestHeader : requestHeaders) {
+            for(String headerKeyToRedact : requestHeadersToRedact) {
+                if(requestHeader.startsWith(headerKeyToRedact)) {
+                    Collections.replaceAll(requestHeaders, requestHeader, headerKeyToRedact + " : [PII_REDACTED]");
+                    break;
+                }
+            }
+        }
     }
-    
+    private static String[] requestHeadersToRedact = {"Authorization"};
     /**
      * Gets the The HTTP response message
      *


### PR DESCRIPTION
<!-- Read me before you submit this pull request

First off, thank you for opening this pull request! We do appreciate it.

The requests and models for this client library are generated. We won't be accepting pull requests for those code files. With that said, we do appreciate
it when you open pull requests with the proposed file changes, as we'll use that to help guide us in updating our template files.

-->

<!-- Optional. Set the issues that this pull request fixes. Delete 'Fixes #' if there isn't an issue associated with this pull request. -->
Fixes #387

<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request
- error messages look like this instead of containing the JWT
```
PUT https://graph.microsoft.com/v1.0/groups/263746d9-2294-4506-87c4-7d4a50d81332/team
SdkVersion : graph-java/v2.0.0
Authorization : [PII_REDACTED]
{"funSettings":{"allowCustomMemes":false},"memberS[...]
```

<!-- Optional. Provide related links. This might be other pull requests, code files, StackOverflow posts. Delete this section if it is not used. -->
### Other links

<!-- Is this PR adding a new hand crafted extension class? If so, please update $filesThatShouldNotBeDeleted variable in .azure-pipelines/generate-v1.0-models.yml file, so that it doesn't get deleted by auto generation pipeline.-->
-
