### PR TITLE
bugfix/singlevalueextendedproperties deserialization

### DIFF
--- a/src/main/java/com/microsoft/graph/callrecords/models/extensions/CallRecord.java
+++ b/src/main/java/com/microsoft/graph/callrecords/models/extensions/CallRecord.java
@@ -6,14 +6,12 @@ package com.microsoft.graph.callrecords.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.callrecords.models.generated.Modality;
 import com.microsoft.graph.models.extensions.IdentitySet;
 import com.microsoft.graph.callrecords.models.generated.CallType;
 import com.microsoft.graph.callrecords.models.extensions.Session;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.callrecords.requests.extensions.SessionCollectionResponse;
 import com.microsoft.graph.callrecords.requests.extensions.SessionCollectionPage;
 
 
@@ -150,19 +148,7 @@ public class CallRecord extends Entity implements IJsonBackedObject {
 
 
         if (json.has("sessions")) {
-            final SessionCollectionResponse response = new SessionCollectionResponse();
-            if (json.has("sessions@odata.nextLink")) {
-                response.nextLink = json.get("sessions@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("sessions").toString(), JsonObject[].class);
-            final Session[] array = new Session[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), Session.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            sessions = new SessionCollectionPage(response, null);
+            sessions = serializer.deserializeObject(json.get("sessions").toString(), SessionCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/callrecords/models/extensions/ClientUserAgent.java
+++ b/src/main/java/com/microsoft/graph/callrecords/models/extensions/ClientUserAgent.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.callrecords.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.callrecords.models.generated.ClientPlatform;
 import com.microsoft.graph.callrecords.models.generated.ProductFamily;

--- a/src/main/java/com/microsoft/graph/callrecords/models/extensions/DeviceInfo.java
+++ b/src/main/java/com/microsoft/graph/callrecords/models/extensions/DeviceInfo.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.callrecords.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/callrecords/models/extensions/Endpoint.java
+++ b/src/main/java/com/microsoft/graph/callrecords/models/extensions/Endpoint.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.callrecords.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.callrecords.models.extensions.UserAgent;
 

--- a/src/main/java/com/microsoft/graph/callrecords/models/extensions/FailureInfo.java
+++ b/src/main/java/com/microsoft/graph/callrecords/models/extensions/FailureInfo.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.callrecords.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.callrecords.models.generated.FailureStage;
 

--- a/src/main/java/com/microsoft/graph/callrecords/models/extensions/FeedbackTokenSet.java
+++ b/src/main/java/com/microsoft/graph/callrecords/models/extensions/FeedbackTokenSet.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.callrecords.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/callrecords/models/extensions/Media.java
+++ b/src/main/java/com/microsoft/graph/callrecords/models/extensions/Media.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.callrecords.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.callrecords.models.extensions.DeviceInfo;
 import com.microsoft.graph.callrecords.models.extensions.NetworkInfo;

--- a/src/main/java/com/microsoft/graph/callrecords/models/extensions/MediaStream.java
+++ b/src/main/java/com/microsoft/graph/callrecords/models/extensions/MediaStream.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.callrecords.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.callrecords.models.generated.MediaStreamDirection;
 

--- a/src/main/java/com/microsoft/graph/callrecords/models/extensions/NetworkInfo.java
+++ b/src/main/java/com/microsoft/graph/callrecords/models/extensions/NetworkInfo.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.callrecords.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.callrecords.models.generated.NetworkConnectionType;
 import com.microsoft.graph.callrecords.models.generated.WifiBand;

--- a/src/main/java/com/microsoft/graph/callrecords/models/extensions/ParticipantEndpoint.java
+++ b/src/main/java/com/microsoft/graph/callrecords/models/extensions/ParticipantEndpoint.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.callrecords.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.callrecords.models.extensions.UserFeedback;
 import com.microsoft.graph.models.extensions.IdentitySet;

--- a/src/main/java/com/microsoft/graph/callrecords/models/extensions/Segment.java
+++ b/src/main/java/com/microsoft/graph/callrecords/models/extensions/Segment.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.callrecords.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.callrecords.models.extensions.Endpoint;
 import com.microsoft.graph.callrecords.models.extensions.FailureInfo;

--- a/src/main/java/com/microsoft/graph/callrecords/models/extensions/ServiceEndpoint.java
+++ b/src/main/java/com/microsoft/graph/callrecords/models/extensions/ServiceEndpoint.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.callrecords.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.callrecords.models.extensions.Endpoint;
 

--- a/src/main/java/com/microsoft/graph/callrecords/models/extensions/ServiceUserAgent.java
+++ b/src/main/java/com/microsoft/graph/callrecords/models/extensions/ServiceUserAgent.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.callrecords.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.callrecords.models.generated.ServiceRole;
 import com.microsoft.graph.callrecords.models.extensions.UserAgent;

--- a/src/main/java/com/microsoft/graph/callrecords/models/extensions/Session.java
+++ b/src/main/java/com/microsoft/graph/callrecords/models/extensions/Session.java
@@ -6,14 +6,12 @@ package com.microsoft.graph.callrecords.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.callrecords.models.extensions.Endpoint;
 import com.microsoft.graph.callrecords.models.extensions.FailureInfo;
 import com.microsoft.graph.callrecords.models.generated.Modality;
 import com.microsoft.graph.callrecords.models.extensions.Segment;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.callrecords.requests.extensions.SegmentCollectionResponse;
 import com.microsoft.graph.callrecords.requests.extensions.SegmentCollectionPage;
 
 
@@ -126,19 +124,7 @@ public class Session extends Entity implements IJsonBackedObject {
 
 
         if (json.has("segments")) {
-            final SegmentCollectionResponse response = new SegmentCollectionResponse();
-            if (json.has("segments@odata.nextLink")) {
-                response.nextLink = json.get("segments@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("segments").toString(), JsonObject[].class);
-            final Segment[] array = new Segment[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), Segment.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            segments = new SegmentCollectionPage(response, null);
+            segments = serializer.deserializeObject(json.get("segments").toString(), SegmentCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/callrecords/models/extensions/UserAgent.java
+++ b/src/main/java/com/microsoft/graph/callrecords/models/extensions/UserAgent.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.callrecords.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/callrecords/models/extensions/UserFeedback.java
+++ b/src/main/java/com/microsoft/graph/callrecords/models/extensions/UserFeedback.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.callrecords.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.callrecords.models.generated.UserFeedbackRating;
 import com.microsoft.graph.callrecords.models.extensions.FeedbackTokenSet;

--- a/src/main/java/com/microsoft/graph/models/extensions/AadUserConversationMember.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/AadUserConversationMember.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.User;
 import com.microsoft.graph.models.extensions.ConversationMember;

--- a/src/main/java/com/microsoft/graph/models/extensions/AccessAction.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/AccessAction.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ActivityBasedTimeoutPolicy.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ActivityBasedTimeoutPolicy.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.StsPolicy;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ActivityHistoryItem.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ActivityHistoryItem.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.Status;
 import com.microsoft.graph.models.extensions.UserActivity;

--- a/src/main/java/com/microsoft/graph/models/extensions/AddIn.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/AddIn.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.KeyValue;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/AdministrativeUnit.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/AdministrativeUnit.java
@@ -6,16 +6,12 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.DirectoryObject;
 import com.microsoft.graph.models.extensions.ScopedRoleMembership;
 import com.microsoft.graph.models.extensions.Extension;
-import com.microsoft.graph.requests.extensions.DirectoryObjectCollectionResponse;
 import com.microsoft.graph.requests.extensions.DirectoryObjectCollectionPage;
-import com.microsoft.graph.requests.extensions.ScopedRoleMembershipCollectionResponse;
 import com.microsoft.graph.requests.extensions.ScopedRoleMembershipCollectionPage;
-import com.microsoft.graph.requests.extensions.ExtensionCollectionResponse;
 import com.microsoft.graph.requests.extensions.ExtensionCollectionPage;
 
 
@@ -118,51 +114,15 @@ public class AdministrativeUnit extends DirectoryObject implements IJsonBackedOb
 
 
         if (json.has("members")) {
-            final DirectoryObjectCollectionResponse response = new DirectoryObjectCollectionResponse();
-            if (json.has("members@odata.nextLink")) {
-                response.nextLink = json.get("members@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("members").toString(), JsonObject[].class);
-            final DirectoryObject[] array = new DirectoryObject[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DirectoryObject.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            members = new DirectoryObjectCollectionPage(response, null);
+            members = serializer.deserializeObject(json.get("members").toString(), DirectoryObjectCollectionPage.class);
         }
 
         if (json.has("scopedRoleMembers")) {
-            final ScopedRoleMembershipCollectionResponse response = new ScopedRoleMembershipCollectionResponse();
-            if (json.has("scopedRoleMembers@odata.nextLink")) {
-                response.nextLink = json.get("scopedRoleMembers@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("scopedRoleMembers").toString(), JsonObject[].class);
-            final ScopedRoleMembership[] array = new ScopedRoleMembership[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), ScopedRoleMembership.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            scopedRoleMembers = new ScopedRoleMembershipCollectionPage(response, null);
+            scopedRoleMembers = serializer.deserializeObject(json.get("scopedRoleMembers").toString(), ScopedRoleMembershipCollectionPage.class);
         }
 
         if (json.has("extensions")) {
-            final ExtensionCollectionResponse response = new ExtensionCollectionResponse();
-            if (json.has("extensions@odata.nextLink")) {
-                response.nextLink = json.get("extensions@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("extensions").toString(), JsonObject[].class);
-            final Extension[] array = new Extension[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), Extension.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            extensions = new ExtensionCollectionPage(response, null);
+            extensions = serializer.deserializeObject(json.get("extensions").toString(), ExtensionCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/Alert.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Alert.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.CloudAppSecurityState;
 import com.microsoft.graph.models.generated.AlertFeedback;

--- a/src/main/java/com/microsoft/graph/models/extensions/AlertHistoryState.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/AlertHistoryState.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.AlertFeedback;
 import com.microsoft.graph.models.generated.AlertStatus;

--- a/src/main/java/com/microsoft/graph/models/extensions/AlertTrigger.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/AlertTrigger.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/AllDevicesAssignmentTarget.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/AllDevicesAssignmentTarget.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.DeviceAndAppManagementAssignmentTarget;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/AllLicensedUsersAssignmentTarget.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/AllLicensedUsersAssignmentTarget.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.DeviceAndAppManagementAssignmentTarget;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/AlternativeSecurityId.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/AlternativeSecurityId.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/AndroidCompliancePolicy.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/AndroidCompliancePolicy.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.DeviceThreatProtectionLevel;
 import com.microsoft.graph.models.generated.AndroidRequiredPasswordType;

--- a/src/main/java/com/microsoft/graph/models/extensions/AndroidCustomConfiguration.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/AndroidCustomConfiguration.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.OmaSetting;
 import com.microsoft.graph.models.extensions.DeviceConfiguration;

--- a/src/main/java/com/microsoft/graph/models/extensions/AndroidGeneralDeviceConfiguration.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/AndroidGeneralDeviceConfiguration.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.AppListItem;
 import com.microsoft.graph.models.generated.AppListType;

--- a/src/main/java/com/microsoft/graph/models/extensions/AndroidLobApp.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/AndroidLobApp.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.AndroidMinimumOperatingSystem;
 import com.microsoft.graph.models.extensions.MobileLobApp;

--- a/src/main/java/com/microsoft/graph/models/extensions/AndroidManagedAppProtection.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/AndroidManagedAppProtection.java
@@ -6,12 +6,10 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.ManagedMobileApp;
 import com.microsoft.graph.models.extensions.ManagedAppPolicyDeploymentSummary;
 import com.microsoft.graph.models.extensions.TargetedManagedAppProtection;
-import com.microsoft.graph.requests.extensions.ManagedMobileAppCollectionResponse;
 import com.microsoft.graph.requests.extensions.ManagedMobileAppCollectionPage;
 
 
@@ -148,19 +146,7 @@ public class AndroidManagedAppProtection extends TargetedManagedAppProtection im
 
 
         if (json.has("apps")) {
-            final ManagedMobileAppCollectionResponse response = new ManagedMobileAppCollectionResponse();
-            if (json.has("apps@odata.nextLink")) {
-                response.nextLink = json.get("apps@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("apps").toString(), JsonObject[].class);
-            final ManagedMobileApp[] array = new ManagedMobileApp[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), ManagedMobileApp.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            apps = new ManagedMobileAppCollectionPage(response, null);
+            apps = serializer.deserializeObject(json.get("apps").toString(), ManagedMobileAppCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/AndroidManagedAppRegistration.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/AndroidManagedAppRegistration.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.ManagedAppRegistration;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/AndroidMinimumOperatingSystem.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/AndroidMinimumOperatingSystem.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/AndroidMobileAppIdentifier.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/AndroidMobileAppIdentifier.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.MobileAppIdentifier;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/AndroidStoreApp.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/AndroidStoreApp.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.AndroidMinimumOperatingSystem;
 import com.microsoft.graph.models.extensions.MobileApp;

--- a/src/main/java/com/microsoft/graph/models/extensions/AndroidWorkProfileCompliancePolicy.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/AndroidWorkProfileCompliancePolicy.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.DeviceThreatProtectionLevel;
 import com.microsoft.graph.models.generated.AndroidRequiredPasswordType;

--- a/src/main/java/com/microsoft/graph/models/extensions/AndroidWorkProfileCustomConfiguration.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/AndroidWorkProfileCustomConfiguration.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.OmaSetting;
 import com.microsoft.graph.models.extensions.DeviceConfiguration;

--- a/src/main/java/com/microsoft/graph/models/extensions/AndroidWorkProfileGeneralDeviceConfiguration.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/AndroidWorkProfileGeneralDeviceConfiguration.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.AndroidWorkProfileRequiredPasswordType;
 import com.microsoft.graph.models.generated.AndroidWorkProfileCrossProfileDataSharingType;

--- a/src/main/java/com/microsoft/graph/models/extensions/ApiApplication.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ApiApplication.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.PermissionScope;
 import com.microsoft.graph.models.extensions.PreAuthorizedApplication;

--- a/src/main/java/com/microsoft/graph/models/extensions/AppCatalogs.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/AppCatalogs.java
@@ -6,11 +6,9 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.TeamsApp;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.TeamsAppCollectionResponse;
 import com.microsoft.graph.requests.extensions.TeamsAppCollectionPage;
 
 
@@ -75,19 +73,7 @@ public class AppCatalogs extends Entity implements IJsonBackedObject {
 
 
         if (json.has("teamsApps")) {
-            final TeamsAppCollectionResponse response = new TeamsAppCollectionResponse();
-            if (json.has("teamsApps@odata.nextLink")) {
-                response.nextLink = json.get("teamsApps@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("teamsApps").toString(), JsonObject[].class);
-            final TeamsApp[] array = new TeamsApp[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), TeamsApp.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            teamsApps = new TeamsAppCollectionPage(response, null);
+            teamsApps = serializer.deserializeObject(json.get("teamsApps").toString(), TeamsAppCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/AppConfigurationSettingItem.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/AppConfigurationSettingItem.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.MdmAppConfigKeyType;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/AppHostedMediaConfig.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/AppHostedMediaConfig.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.MediaConfig;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/AppIdentity.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/AppIdentity.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/AppListItem.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/AppListItem.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/AppRole.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/AppRole.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/AppRoleAssignment.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/AppRoleAssignment.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.DirectoryObject;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/AppleDeviceFeaturesConfigurationBase.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/AppleDeviceFeaturesConfigurationBase.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.DeviceConfiguration;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ApplePushNotificationCertificate.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ApplePushNotificationCertificate.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Entity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/Application.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Application.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.AddIn;
 import com.microsoft.graph.models.extensions.ApiApplication;
@@ -24,15 +23,10 @@ import com.microsoft.graph.models.extensions.ExtensionProperty;
 import com.microsoft.graph.models.extensions.HomeRealmDiscoveryPolicy;
 import com.microsoft.graph.models.extensions.TokenIssuancePolicy;
 import com.microsoft.graph.models.extensions.TokenLifetimePolicy;
-import com.microsoft.graph.requests.extensions.ExtensionPropertyCollectionResponse;
 import com.microsoft.graph.requests.extensions.ExtensionPropertyCollectionPage;
-import com.microsoft.graph.requests.extensions.HomeRealmDiscoveryPolicyCollectionResponse;
 import com.microsoft.graph.requests.extensions.HomeRealmDiscoveryPolicyCollectionPage;
-import com.microsoft.graph.requests.extensions.DirectoryObjectCollectionResponse;
 import com.microsoft.graph.requests.extensions.DirectoryObjectCollectionPage;
-import com.microsoft.graph.requests.extensions.TokenIssuancePolicyCollectionResponse;
 import com.microsoft.graph.requests.extensions.TokenIssuancePolicyCollectionPage;
-import com.microsoft.graph.requests.extensions.TokenLifetimePolicyCollectionResponse;
 import com.microsoft.graph.requests.extensions.TokenLifetimePolicyCollectionPage;
 
 
@@ -337,83 +331,23 @@ public class Application extends DirectoryObject implements IJsonBackedObject {
 
 
         if (json.has("extensionProperties")) {
-            final ExtensionPropertyCollectionResponse response = new ExtensionPropertyCollectionResponse();
-            if (json.has("extensionProperties@odata.nextLink")) {
-                response.nextLink = json.get("extensionProperties@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("extensionProperties").toString(), JsonObject[].class);
-            final ExtensionProperty[] array = new ExtensionProperty[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), ExtensionProperty.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            extensionProperties = new ExtensionPropertyCollectionPage(response, null);
+            extensionProperties = serializer.deserializeObject(json.get("extensionProperties").toString(), ExtensionPropertyCollectionPage.class);
         }
 
         if (json.has("homeRealmDiscoveryPolicies")) {
-            final HomeRealmDiscoveryPolicyCollectionResponse response = new HomeRealmDiscoveryPolicyCollectionResponse();
-            if (json.has("homeRealmDiscoveryPolicies@odata.nextLink")) {
-                response.nextLink = json.get("homeRealmDiscoveryPolicies@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("homeRealmDiscoveryPolicies").toString(), JsonObject[].class);
-            final HomeRealmDiscoveryPolicy[] array = new HomeRealmDiscoveryPolicy[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), HomeRealmDiscoveryPolicy.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            homeRealmDiscoveryPolicies = new HomeRealmDiscoveryPolicyCollectionPage(response, null);
+            homeRealmDiscoveryPolicies = serializer.deserializeObject(json.get("homeRealmDiscoveryPolicies").toString(), HomeRealmDiscoveryPolicyCollectionPage.class);
         }
 
         if (json.has("owners")) {
-            final DirectoryObjectCollectionResponse response = new DirectoryObjectCollectionResponse();
-            if (json.has("owners@odata.nextLink")) {
-                response.nextLink = json.get("owners@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("owners").toString(), JsonObject[].class);
-            final DirectoryObject[] array = new DirectoryObject[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DirectoryObject.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            owners = new DirectoryObjectCollectionPage(response, null);
+            owners = serializer.deserializeObject(json.get("owners").toString(), DirectoryObjectCollectionPage.class);
         }
 
         if (json.has("tokenIssuancePolicies")) {
-            final TokenIssuancePolicyCollectionResponse response = new TokenIssuancePolicyCollectionResponse();
-            if (json.has("tokenIssuancePolicies@odata.nextLink")) {
-                response.nextLink = json.get("tokenIssuancePolicies@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("tokenIssuancePolicies").toString(), JsonObject[].class);
-            final TokenIssuancePolicy[] array = new TokenIssuancePolicy[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), TokenIssuancePolicy.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            tokenIssuancePolicies = new TokenIssuancePolicyCollectionPage(response, null);
+            tokenIssuancePolicies = serializer.deserializeObject(json.get("tokenIssuancePolicies").toString(), TokenIssuancePolicyCollectionPage.class);
         }
 
         if (json.has("tokenLifetimePolicies")) {
-            final TokenLifetimePolicyCollectionResponse response = new TokenLifetimePolicyCollectionResponse();
-            if (json.has("tokenLifetimePolicies@odata.nextLink")) {
-                response.nextLink = json.get("tokenLifetimePolicies@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("tokenLifetimePolicies").toString(), JsonObject[].class);
-            final TokenLifetimePolicy[] array = new TokenLifetimePolicy[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), TokenLifetimePolicy.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            tokenLifetimePolicies = new TokenLifetimePolicyCollectionPage(response, null);
+            tokenLifetimePolicies = serializer.deserializeObject(json.get("tokenLifetimePolicies").toString(), TokenLifetimePolicyCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/ApplicationEnforcedRestrictionsSessionControl.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ApplicationEnforcedRestrictionsSessionControl.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.ConditionalAccessSessionControl;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/AppliedConditionalAccessPolicy.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/AppliedConditionalAccessPolicy.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.AppliedConditionalAccessPolicyResult;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/AssignedLabel.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/AssignedLabel.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/AssignedLicense.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/AssignedLicense.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/AssignedPlan.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/AssignedPlan.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/Attachment.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Attachment.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Entity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/AttachmentItem.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/AttachmentItem.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.AttachmentType;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/Attendee.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Attendee.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.TimeSlot;
 import com.microsoft.graph.models.extensions.ResponseStatus;

--- a/src/main/java/com/microsoft/graph/models/extensions/AttendeeAvailability.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/AttendeeAvailability.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.AttendeeBase;
 import com.microsoft.graph.models.generated.FreeBusyStatus;

--- a/src/main/java/com/microsoft/graph/models/extensions/AttendeeBase.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/AttendeeBase.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.AttendeeType;
 import com.microsoft.graph.models.extensions.Recipient;

--- a/src/main/java/com/microsoft/graph/models/extensions/Audio.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Audio.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/AudioConferencing.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/AudioConferencing.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/AuditActivityInitiator.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/AuditActivityInitiator.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.AppIdentity;
 import com.microsoft.graph.models.extensions.UserIdentity;

--- a/src/main/java/com/microsoft/graph/models/extensions/AuditLogRoot.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/AuditLogRoot.java
@@ -6,17 +6,13 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.DirectoryAudit;
 import com.microsoft.graph.models.extensions.RestrictedSignIn;
 import com.microsoft.graph.models.extensions.SignIn;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.DirectoryAuditCollectionResponse;
 import com.microsoft.graph.requests.extensions.DirectoryAuditCollectionPage;
-import com.microsoft.graph.requests.extensions.RestrictedSignInCollectionResponse;
 import com.microsoft.graph.requests.extensions.RestrictedSignInCollectionPage;
-import com.microsoft.graph.requests.extensions.SignInCollectionResponse;
 import com.microsoft.graph.requests.extensions.SignInCollectionPage;
 
 
@@ -97,51 +93,15 @@ public class AuditLogRoot extends Entity implements IJsonBackedObject {
 
 
         if (json.has("directoryAudits")) {
-            final DirectoryAuditCollectionResponse response = new DirectoryAuditCollectionResponse();
-            if (json.has("directoryAudits@odata.nextLink")) {
-                response.nextLink = json.get("directoryAudits@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("directoryAudits").toString(), JsonObject[].class);
-            final DirectoryAudit[] array = new DirectoryAudit[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DirectoryAudit.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            directoryAudits = new DirectoryAuditCollectionPage(response, null);
+            directoryAudits = serializer.deserializeObject(json.get("directoryAudits").toString(), DirectoryAuditCollectionPage.class);
         }
 
         if (json.has("restrictedSignIns")) {
-            final RestrictedSignInCollectionResponse response = new RestrictedSignInCollectionResponse();
-            if (json.has("restrictedSignIns@odata.nextLink")) {
-                response.nextLink = json.get("restrictedSignIns@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("restrictedSignIns").toString(), JsonObject[].class);
-            final RestrictedSignIn[] array = new RestrictedSignIn[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), RestrictedSignIn.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            restrictedSignIns = new RestrictedSignInCollectionPage(response, null);
+            restrictedSignIns = serializer.deserializeObject(json.get("restrictedSignIns").toString(), RestrictedSignInCollectionPage.class);
         }
 
         if (json.has("signIns")) {
-            final SignInCollectionResponse response = new SignInCollectionResponse();
-            if (json.has("signIns@odata.nextLink")) {
-                response.nextLink = json.get("signIns@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("signIns").toString(), JsonObject[].class);
-            final SignIn[] array = new SignIn[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), SignIn.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            signIns = new SignInCollectionPage(response, null);
+            signIns = serializer.deserializeObject(json.get("signIns").toString(), SignInCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/AutomaticRepliesMailTips.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/AutomaticRepliesMailTips.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.LocaleInfo;
 import com.microsoft.graph.models.extensions.DateTimeTimeZone;

--- a/src/main/java/com/microsoft/graph/models/extensions/AutomaticRepliesSetting.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/AutomaticRepliesSetting.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.ExternalAudienceScope;
 import com.microsoft.graph.models.extensions.DateTimeTimeZone;

--- a/src/main/java/com/microsoft/graph/models/extensions/AverageComparativeScore.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/AverageComparativeScore.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/BaseItem.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/BaseItem.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.IdentitySet;
 import com.microsoft.graph.models.extensions.ItemReference;

--- a/src/main/java/com/microsoft/graph/models/extensions/BaseItemVersion.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/BaseItemVersion.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.IdentitySet;
 import com.microsoft.graph.models.extensions.PublicationFacet;

--- a/src/main/java/com/microsoft/graph/models/extensions/BitLockerRemovableDrivePolicy.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/BitLockerRemovableDrivePolicy.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.BitLockerEncryptionMethod;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/BooleanColumn.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/BooleanColumn.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/CalculatedColumn.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/CalculatedColumn.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/Calendar.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Calendar.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.OnlineMeetingProviderType;
 import com.microsoft.graph.models.generated.CalendarColor;
@@ -16,13 +15,9 @@ import com.microsoft.graph.models.extensions.Event;
 import com.microsoft.graph.models.extensions.MultiValueLegacyExtendedProperty;
 import com.microsoft.graph.models.extensions.SingleValueLegacyExtendedProperty;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.CalendarPermissionCollectionResponse;
 import com.microsoft.graph.requests.extensions.CalendarPermissionCollectionPage;
-import com.microsoft.graph.requests.extensions.EventCollectionResponse;
 import com.microsoft.graph.requests.extensions.EventCollectionPage;
-import com.microsoft.graph.requests.extensions.MultiValueLegacyExtendedPropertyCollectionResponse;
 import com.microsoft.graph.requests.extensions.MultiValueLegacyExtendedPropertyCollectionPage;
-import com.microsoft.graph.requests.extensions.SingleValueLegacyExtendedPropertyCollectionResponse;
 import com.microsoft.graph.requests.extensions.SingleValueLegacyExtendedPropertyCollectionPage;
 
 
@@ -207,83 +202,23 @@ public class Calendar extends Entity implements IJsonBackedObject {
 
 
         if (json.has("calendarPermissions")) {
-            final CalendarPermissionCollectionResponse response = new CalendarPermissionCollectionResponse();
-            if (json.has("calendarPermissions@odata.nextLink")) {
-                response.nextLink = json.get("calendarPermissions@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("calendarPermissions").toString(), JsonObject[].class);
-            final CalendarPermission[] array = new CalendarPermission[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), CalendarPermission.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            calendarPermissions = new CalendarPermissionCollectionPage(response, null);
+            calendarPermissions = serializer.deserializeObject(json.get("calendarPermissions").toString(), CalendarPermissionCollectionPage.class);
         }
 
         if (json.has("calendarView")) {
-            final EventCollectionResponse response = new EventCollectionResponse();
-            if (json.has("calendarView@odata.nextLink")) {
-                response.nextLink = json.get("calendarView@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("calendarView").toString(), JsonObject[].class);
-            final Event[] array = new Event[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), Event.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            calendarView = new EventCollectionPage(response, null);
+            calendarView = serializer.deserializeObject(json.get("calendarView").toString(), EventCollectionPage.class);
         }
 
         if (json.has("events")) {
-            final EventCollectionResponse response = new EventCollectionResponse();
-            if (json.has("events@odata.nextLink")) {
-                response.nextLink = json.get("events@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("events").toString(), JsonObject[].class);
-            final Event[] array = new Event[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), Event.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            events = new EventCollectionPage(response, null);
+            events = serializer.deserializeObject(json.get("events").toString(), EventCollectionPage.class);
         }
 
         if (json.has("multiValueExtendedProperties")) {
-            final MultiValueLegacyExtendedPropertyCollectionResponse response = new MultiValueLegacyExtendedPropertyCollectionResponse();
-            if (json.has("multiValueExtendedProperties@odata.nextLink")) {
-                response.nextLink = json.get("multiValueExtendedProperties@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("multiValueExtendedProperties").toString(), JsonObject[].class);
-            final MultiValueLegacyExtendedProperty[] array = new MultiValueLegacyExtendedProperty[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), MultiValueLegacyExtendedProperty.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            multiValueExtendedProperties = new MultiValueLegacyExtendedPropertyCollectionPage(response, null);
+            multiValueExtendedProperties = serializer.deserializeObject(json.get("multiValueExtendedProperties").toString(), MultiValueLegacyExtendedPropertyCollectionPage.class);
         }
 
         if (json.has("singleValueExtendedProperties")) {
-            final SingleValueLegacyExtendedPropertyCollectionResponse response = new SingleValueLegacyExtendedPropertyCollectionResponse();
-            if (json.has("singleValueExtendedProperties@odata.nextLink")) {
-                response.nextLink = json.get("singleValueExtendedProperties@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("singleValueExtendedProperties").toString(), JsonObject[].class);
-            final SingleValueLegacyExtendedProperty[] array = new SingleValueLegacyExtendedProperty[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), SingleValueLegacyExtendedProperty.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            singleValueExtendedProperties = new SingleValueLegacyExtendedPropertyCollectionPage(response, null);
+            singleValueExtendedProperties = serializer.deserializeObject(json.get("singleValueExtendedProperties").toString(), SingleValueLegacyExtendedPropertyCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/CalendarGroup.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/CalendarGroup.java
@@ -6,11 +6,9 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Calendar;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.CalendarCollectionResponse;
 import com.microsoft.graph.requests.extensions.CalendarCollectionPage;
 
 
@@ -99,19 +97,7 @@ public class CalendarGroup extends Entity implements IJsonBackedObject {
 
 
         if (json.has("calendars")) {
-            final CalendarCollectionResponse response = new CalendarCollectionResponse();
-            if (json.has("calendars@odata.nextLink")) {
-                response.nextLink = json.get("calendars@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("calendars").toString(), JsonObject[].class);
-            final Calendar[] array = new Calendar[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), Calendar.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            calendars = new CalendarCollectionPage(response, null);
+            calendars = serializer.deserializeObject(json.get("calendars").toString(), CalendarCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/CalendarPermission.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/CalendarPermission.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.CalendarRoleType;
 import com.microsoft.graph.models.extensions.EmailAddress;

--- a/src/main/java/com/microsoft/graph/models/extensions/CalendarSharingMessage.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/CalendarSharingMessage.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.CalendarSharingMessageAction;
 import com.microsoft.graph.models.extensions.Message;

--- a/src/main/java/com/microsoft/graph/models/extensions/CalendarSharingMessageAction.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/CalendarSharingMessageAction.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.CalendarSharingAction;
 import com.microsoft.graph.models.generated.CalendarSharingActionType;

--- a/src/main/java/com/microsoft/graph/models/extensions/Call.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Call.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.CallOptions;
 import com.microsoft.graph.models.extensions.CallRoute;
@@ -26,9 +25,7 @@ import com.microsoft.graph.models.extensions.CallTranscriptionInfo;
 import com.microsoft.graph.models.extensions.CommsOperation;
 import com.microsoft.graph.models.extensions.Participant;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.CommsOperationCollectionResponse;
 import com.microsoft.graph.requests.extensions.CommsOperationCollectionPage;
-import com.microsoft.graph.requests.extensions.ParticipantCollectionResponse;
 import com.microsoft.graph.requests.extensions.ParticipantCollectionPage;
 
 
@@ -261,35 +258,11 @@ public class Call extends Entity implements IJsonBackedObject {
 
 
         if (json.has("operations")) {
-            final CommsOperationCollectionResponse response = new CommsOperationCollectionResponse();
-            if (json.has("operations@odata.nextLink")) {
-                response.nextLink = json.get("operations@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("operations").toString(), JsonObject[].class);
-            final CommsOperation[] array = new CommsOperation[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), CommsOperation.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            operations = new CommsOperationCollectionPage(response, null);
+            operations = serializer.deserializeObject(json.get("operations").toString(), CommsOperationCollectionPage.class);
         }
 
         if (json.has("participants")) {
-            final ParticipantCollectionResponse response = new ParticipantCollectionResponse();
-            if (json.has("participants@odata.nextLink")) {
-                response.nextLink = json.get("participants@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("participants").toString(), JsonObject[].class);
-            final Participant[] array = new Participant[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), Participant.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            participants = new ParticipantCollectionPage(response, null);
+            participants = serializer.deserializeObject(json.get("participants").toString(), ParticipantCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/CallMediaState.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/CallMediaState.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.MediaState;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/CallOptions.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/CallOptions.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/CallRoute.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/CallRoute.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.IdentitySet;
 import com.microsoft.graph.models.generated.RoutingType;

--- a/src/main/java/com/microsoft/graph/models/extensions/CallTranscriptionInfo.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/CallTranscriptionInfo.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.CallTranscriptionState;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/CancelMediaProcessingOperation.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/CancelMediaProcessingOperation.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.CommsOperation;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/CertificateAuthority.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/CertificateAuthority.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/CertificateBasedAuthConfiguration.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/CertificateBasedAuthConfiguration.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.CertificateAuthority;
 import com.microsoft.graph.models.extensions.Entity;

--- a/src/main/java/com/microsoft/graph/models/extensions/CertificationControl.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/CertificationControl.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ChangeNotification.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ChangeNotification.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.ChangeType;
 import com.microsoft.graph.models.extensions.ChangeNotificationEncryptedContent;

--- a/src/main/java/com/microsoft/graph/models/extensions/ChangeNotificationCollection.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ChangeNotificationCollection.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.ChangeNotification;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ChangeNotificationEncryptedContent.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ChangeNotificationEncryptedContent.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ChangeTrackedEntity.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ChangeTrackedEntity.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.IdentitySet;
 import com.microsoft.graph.models.extensions.Entity;

--- a/src/main/java/com/microsoft/graph/models/extensions/Channel.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Channel.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.ChannelMembershipType;
 import com.microsoft.graph.models.extensions.DriveItem;
@@ -14,11 +13,8 @@ import com.microsoft.graph.models.extensions.ConversationMember;
 import com.microsoft.graph.models.extensions.ChatMessage;
 import com.microsoft.graph.models.extensions.TeamsTab;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.ConversationMemberCollectionResponse;
 import com.microsoft.graph.requests.extensions.ConversationMemberCollectionPage;
-import com.microsoft.graph.requests.extensions.ChatMessageCollectionResponse;
 import com.microsoft.graph.requests.extensions.ChatMessageCollectionPage;
-import com.microsoft.graph.requests.extensions.TeamsTabCollectionResponse;
 import com.microsoft.graph.requests.extensions.TeamsTabCollectionPage;
 
 
@@ -147,51 +143,15 @@ public class Channel extends Entity implements IJsonBackedObject {
 
 
         if (json.has("members")) {
-            final ConversationMemberCollectionResponse response = new ConversationMemberCollectionResponse();
-            if (json.has("members@odata.nextLink")) {
-                response.nextLink = json.get("members@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("members").toString(), JsonObject[].class);
-            final ConversationMember[] array = new ConversationMember[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), ConversationMember.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            members = new ConversationMemberCollectionPage(response, null);
+            members = serializer.deserializeObject(json.get("members").toString(), ConversationMemberCollectionPage.class);
         }
 
         if (json.has("messages")) {
-            final ChatMessageCollectionResponse response = new ChatMessageCollectionResponse();
-            if (json.has("messages@odata.nextLink")) {
-                response.nextLink = json.get("messages@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("messages").toString(), JsonObject[].class);
-            final ChatMessage[] array = new ChatMessage[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), ChatMessage.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            messages = new ChatMessageCollectionPage(response, null);
+            messages = serializer.deserializeObject(json.get("messages").toString(), ChatMessageCollectionPage.class);
         }
 
         if (json.has("tabs")) {
-            final TeamsTabCollectionResponse response = new TeamsTabCollectionResponse();
-            if (json.has("tabs@odata.nextLink")) {
-                response.nextLink = json.get("tabs@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("tabs").toString(), JsonObject[].class);
-            final TeamsTab[] array = new TeamsTab[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), TeamsTab.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            tabs = new TeamsTabCollectionPage(response, null);
+            tabs = serializer.deserializeObject(json.get("tabs").toString(), TeamsTabCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/Chat.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Chat.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Entity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ChatInfo.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ChatInfo.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ChatMessage.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ChatMessage.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.ChatMessageAttachment;
 import com.microsoft.graph.models.extensions.ItemBody;
@@ -19,9 +18,7 @@ import com.microsoft.graph.models.extensions.ChatMessageReaction;
 import com.microsoft.graph.models.extensions.ChatMessageHostedContent;
 import com.microsoft.graph.models.extensions.ChatMessage;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.ChatMessageHostedContentCollectionResponse;
 import com.microsoft.graph.requests.extensions.ChatMessageHostedContentCollectionPage;
-import com.microsoft.graph.requests.extensions.ChatMessageCollectionResponse;
 import com.microsoft.graph.requests.extensions.ChatMessageCollectionPage;
 
 
@@ -238,35 +235,11 @@ public class ChatMessage extends Entity implements IJsonBackedObject {
 
 
         if (json.has("hostedContents")) {
-            final ChatMessageHostedContentCollectionResponse response = new ChatMessageHostedContentCollectionResponse();
-            if (json.has("hostedContents@odata.nextLink")) {
-                response.nextLink = json.get("hostedContents@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("hostedContents").toString(), JsonObject[].class);
-            final ChatMessageHostedContent[] array = new ChatMessageHostedContent[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), ChatMessageHostedContent.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            hostedContents = new ChatMessageHostedContentCollectionPage(response, null);
+            hostedContents = serializer.deserializeObject(json.get("hostedContents").toString(), ChatMessageHostedContentCollectionPage.class);
         }
 
         if (json.has("replies")) {
-            final ChatMessageCollectionResponse response = new ChatMessageCollectionResponse();
-            if (json.has("replies@odata.nextLink")) {
-                response.nextLink = json.get("replies@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("replies").toString(), JsonObject[].class);
-            final ChatMessage[] array = new ChatMessage[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), ChatMessage.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            replies = new ChatMessageCollectionPage(response, null);
+            replies = serializer.deserializeObject(json.get("replies").toString(), ChatMessageCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/ChatMessageAttachment.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ChatMessageAttachment.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ChatMessageHostedContent.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ChatMessageHostedContent.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Entity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ChatMessageMention.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ChatMessageMention.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.IdentitySet;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ChatMessagePolicyViolation.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ChatMessagePolicyViolation.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.ChatMessagePolicyViolationDlpActionTypes;
 import com.microsoft.graph.models.extensions.ChatMessagePolicyViolationPolicyTip;

--- a/src/main/java/com/microsoft/graph/models/extensions/ChatMessagePolicyViolationPolicyTip.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ChatMessagePolicyViolationPolicyTip.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ChatMessageReaction.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ChatMessageReaction.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.IdentitySet;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ChoiceColumn.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ChoiceColumn.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ClaimsMappingPolicy.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ClaimsMappingPolicy.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.StsPolicy;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/CloudAppSecuritySessionControl.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/CloudAppSecuritySessionControl.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.CloudAppSecuritySessionControlType;
 import com.microsoft.graph.models.extensions.ConditionalAccessSessionControl;

--- a/src/main/java/com/microsoft/graph/models/extensions/CloudAppSecurityState.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/CloudAppSecurityState.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/CloudCommunications.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/CloudCommunications.java
@@ -6,17 +6,13 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Call;
 import com.microsoft.graph.callrecords.models.extensions.CallRecord;
 import com.microsoft.graph.models.extensions.OnlineMeeting;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.CallCollectionResponse;
 import com.microsoft.graph.requests.extensions.CallCollectionPage;
-import com.microsoft.graph.callrecords.requests.extensions.CallRecordCollectionResponse;
 import com.microsoft.graph.callrecords.requests.extensions.CallRecordCollectionPage;
-import com.microsoft.graph.requests.extensions.OnlineMeetingCollectionResponse;
 import com.microsoft.graph.requests.extensions.OnlineMeetingCollectionPage;
 
 
@@ -97,51 +93,15 @@ public class CloudCommunications extends Entity implements IJsonBackedObject {
 
 
         if (json.has("calls")) {
-            final CallCollectionResponse response = new CallCollectionResponse();
-            if (json.has("calls@odata.nextLink")) {
-                response.nextLink = json.get("calls@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("calls").toString(), JsonObject[].class);
-            final Call[] array = new Call[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), Call.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            calls = new CallCollectionPage(response, null);
+            calls = serializer.deserializeObject(json.get("calls").toString(), CallCollectionPage.class);
         }
 
         if (json.has("callRecords")) {
-            final CallRecordCollectionResponse response = new CallRecordCollectionResponse();
-            if (json.has("callRecords@odata.nextLink")) {
-                response.nextLink = json.get("callRecords@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("callRecords").toString(), JsonObject[].class);
-            final CallRecord[] array = new CallRecord[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), CallRecord.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            callRecords = new CallRecordCollectionPage(response, null);
+            callRecords = serializer.deserializeObject(json.get("callRecords").toString(), CallRecordCollectionPage.class);
         }
 
         if (json.has("onlineMeetings")) {
-            final OnlineMeetingCollectionResponse response = new OnlineMeetingCollectionResponse();
-            if (json.has("onlineMeetings@odata.nextLink")) {
-                response.nextLink = json.get("onlineMeetings@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("onlineMeetings").toString(), JsonObject[].class);
-            final OnlineMeeting[] array = new OnlineMeeting[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), OnlineMeeting.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            onlineMeetings = new OnlineMeetingCollectionPage(response, null);
+            onlineMeetings = serializer.deserializeObject(json.get("onlineMeetings").toString(), OnlineMeetingCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/ColumnDefinition.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ColumnDefinition.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.BooleanColumn;
 import com.microsoft.graph.models.extensions.CalculatedColumn;

--- a/src/main/java/com/microsoft/graph/models/extensions/ColumnLink.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ColumnLink.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Entity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/CommsNotification.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/CommsNotification.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.ChangeType;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/CommsNotifications.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/CommsNotifications.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.CommsNotification;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/CommsOperation.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/CommsOperation.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.ResultInfo;
 import com.microsoft.graph.models.generated.OperationStatus;

--- a/src/main/java/com/microsoft/graph/models/extensions/ComplexExtensionValue.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ComplexExtensionValue.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ComplianceInformation.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ComplianceInformation.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.CertificationControl;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ComplianceManagementPartner.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ComplianceManagementPartner.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.ComplianceManagementPartnerAssignment;
 import com.microsoft.graph.models.generated.DeviceManagementPartnerTenantState;

--- a/src/main/java/com/microsoft/graph/models/extensions/ComplianceManagementPartnerAssignment.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ComplianceManagementPartnerAssignment.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.DeviceAndAppManagementAssignmentTarget;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ConditionalAccessApplications.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ConditionalAccessApplications.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ConditionalAccessConditionSet.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ConditionalAccessConditionSet.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.ConditionalAccessApplications;
 import com.microsoft.graph.models.generated.ConditionalAccessClientApp;

--- a/src/main/java/com/microsoft/graph/models/extensions/ConditionalAccessGrantControls.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ConditionalAccessGrantControls.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.ConditionalAccessGrantControl;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ConditionalAccessLocations.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ConditionalAccessLocations.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ConditionalAccessPlatforms.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ConditionalAccessPlatforms.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.ConditionalAccessDevicePlatform;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ConditionalAccessPolicy.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ConditionalAccessPolicy.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.ConditionalAccessConditionSet;
 import com.microsoft.graph.models.extensions.ConditionalAccessGrantControls;

--- a/src/main/java/com/microsoft/graph/models/extensions/ConditionalAccessRoot.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ConditionalAccessRoot.java
@@ -6,14 +6,11 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.NamedLocation;
 import com.microsoft.graph.models.extensions.ConditionalAccessPolicy;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.NamedLocationCollectionResponse;
 import com.microsoft.graph.requests.extensions.NamedLocationCollectionPage;
-import com.microsoft.graph.requests.extensions.ConditionalAccessPolicyCollectionResponse;
 import com.microsoft.graph.requests.extensions.ConditionalAccessPolicyCollectionPage;
 
 
@@ -86,35 +83,11 @@ public class ConditionalAccessRoot extends Entity implements IJsonBackedObject {
 
 
         if (json.has("namedLocations")) {
-            final NamedLocationCollectionResponse response = new NamedLocationCollectionResponse();
-            if (json.has("namedLocations@odata.nextLink")) {
-                response.nextLink = json.get("namedLocations@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("namedLocations").toString(), JsonObject[].class);
-            final NamedLocation[] array = new NamedLocation[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), NamedLocation.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            namedLocations = new NamedLocationCollectionPage(response, null);
+            namedLocations = serializer.deserializeObject(json.get("namedLocations").toString(), NamedLocationCollectionPage.class);
         }
 
         if (json.has("policies")) {
-            final ConditionalAccessPolicyCollectionResponse response = new ConditionalAccessPolicyCollectionResponse();
-            if (json.has("policies@odata.nextLink")) {
-                response.nextLink = json.get("policies@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("policies").toString(), JsonObject[].class);
-            final ConditionalAccessPolicy[] array = new ConditionalAccessPolicy[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), ConditionalAccessPolicy.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            policies = new ConditionalAccessPolicyCollectionPage(response, null);
+            policies = serializer.deserializeObject(json.get("policies").toString(), ConditionalAccessPolicyCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/ConditionalAccessSessionControl.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ConditionalAccessSessionControl.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ConditionalAccessSessionControls.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ConditionalAccessSessionControls.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.ApplicationEnforcedRestrictionsSessionControl;
 import com.microsoft.graph.models.extensions.CloudAppSecuritySessionControl;

--- a/src/main/java/com/microsoft/graph/models/extensions/ConditionalAccessUsers.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ConditionalAccessUsers.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ConfigurationManagerClientEnabledFeatures.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ConfigurationManagerClientEnabledFeatures.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/Contact.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Contact.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.PhysicalAddress;
 import com.microsoft.graph.models.extensions.EmailAddress;
@@ -15,11 +14,8 @@ import com.microsoft.graph.models.extensions.MultiValueLegacyExtendedProperty;
 import com.microsoft.graph.models.extensions.ProfilePhoto;
 import com.microsoft.graph.models.extensions.SingleValueLegacyExtendedProperty;
 import com.microsoft.graph.models.extensions.OutlookItem;
-import com.microsoft.graph.requests.extensions.ExtensionCollectionResponse;
 import com.microsoft.graph.requests.extensions.ExtensionCollectionPage;
-import com.microsoft.graph.requests.extensions.MultiValueLegacyExtendedPropertyCollectionResponse;
 import com.microsoft.graph.requests.extensions.MultiValueLegacyExtendedPropertyCollectionPage;
-import com.microsoft.graph.requests.extensions.SingleValueLegacyExtendedPropertyCollectionResponse;
 import com.microsoft.graph.requests.extensions.SingleValueLegacyExtendedPropertyCollectionPage;
 
 
@@ -372,51 +368,15 @@ public class Contact extends OutlookItem implements IJsonBackedObject {
 
 
         if (json.has("extensions")) {
-            final ExtensionCollectionResponse response = new ExtensionCollectionResponse();
-            if (json.has("extensions@odata.nextLink")) {
-                response.nextLink = json.get("extensions@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("extensions").toString(), JsonObject[].class);
-            final Extension[] array = new Extension[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), Extension.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            extensions = new ExtensionCollectionPage(response, null);
+            extensions = serializer.deserializeObject(json.get("extensions").toString(), ExtensionCollectionPage.class);
         }
 
         if (json.has("multiValueExtendedProperties")) {
-            final MultiValueLegacyExtendedPropertyCollectionResponse response = new MultiValueLegacyExtendedPropertyCollectionResponse();
-            if (json.has("multiValueExtendedProperties@odata.nextLink")) {
-                response.nextLink = json.get("multiValueExtendedProperties@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("multiValueExtendedProperties").toString(), JsonObject[].class);
-            final MultiValueLegacyExtendedProperty[] array = new MultiValueLegacyExtendedProperty[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), MultiValueLegacyExtendedProperty.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            multiValueExtendedProperties = new MultiValueLegacyExtendedPropertyCollectionPage(response, null);
+            multiValueExtendedProperties = serializer.deserializeObject(json.get("multiValueExtendedProperties").toString(), MultiValueLegacyExtendedPropertyCollectionPage.class);
         }
 
         if (json.has("singleValueExtendedProperties")) {
-            final SingleValueLegacyExtendedPropertyCollectionResponse response = new SingleValueLegacyExtendedPropertyCollectionResponse();
-            if (json.has("singleValueExtendedProperties@odata.nextLink")) {
-                response.nextLink = json.get("singleValueExtendedProperties@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("singleValueExtendedProperties").toString(), JsonObject[].class);
-            final SingleValueLegacyExtendedProperty[] array = new SingleValueLegacyExtendedProperty[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), SingleValueLegacyExtendedProperty.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            singleValueExtendedProperties = new SingleValueLegacyExtendedPropertyCollectionPage(response, null);
+            singleValueExtendedProperties = serializer.deserializeObject(json.get("singleValueExtendedProperties").toString(), SingleValueLegacyExtendedPropertyCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/ContactFolder.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ContactFolder.java
@@ -6,20 +6,15 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.ContactFolder;
 import com.microsoft.graph.models.extensions.Contact;
 import com.microsoft.graph.models.extensions.MultiValueLegacyExtendedProperty;
 import com.microsoft.graph.models.extensions.SingleValueLegacyExtendedProperty;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.ContactFolderCollectionResponse;
 import com.microsoft.graph.requests.extensions.ContactFolderCollectionPage;
-import com.microsoft.graph.requests.extensions.ContactCollectionResponse;
 import com.microsoft.graph.requests.extensions.ContactCollectionPage;
-import com.microsoft.graph.requests.extensions.MultiValueLegacyExtendedPropertyCollectionResponse;
 import com.microsoft.graph.requests.extensions.MultiValueLegacyExtendedPropertyCollectionPage;
-import com.microsoft.graph.requests.extensions.SingleValueLegacyExtendedPropertyCollectionResponse;
 import com.microsoft.graph.requests.extensions.SingleValueLegacyExtendedPropertyCollectionPage;
 
 
@@ -124,67 +119,19 @@ public class ContactFolder extends Entity implements IJsonBackedObject {
 
 
         if (json.has("childFolders")) {
-            final ContactFolderCollectionResponse response = new ContactFolderCollectionResponse();
-            if (json.has("childFolders@odata.nextLink")) {
-                response.nextLink = json.get("childFolders@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("childFolders").toString(), JsonObject[].class);
-            final ContactFolder[] array = new ContactFolder[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), ContactFolder.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            childFolders = new ContactFolderCollectionPage(response, null);
+            childFolders = serializer.deserializeObject(json.get("childFolders").toString(), ContactFolderCollectionPage.class);
         }
 
         if (json.has("contacts")) {
-            final ContactCollectionResponse response = new ContactCollectionResponse();
-            if (json.has("contacts@odata.nextLink")) {
-                response.nextLink = json.get("contacts@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("contacts").toString(), JsonObject[].class);
-            final Contact[] array = new Contact[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), Contact.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            contacts = new ContactCollectionPage(response, null);
+            contacts = serializer.deserializeObject(json.get("contacts").toString(), ContactCollectionPage.class);
         }
 
         if (json.has("multiValueExtendedProperties")) {
-            final MultiValueLegacyExtendedPropertyCollectionResponse response = new MultiValueLegacyExtendedPropertyCollectionResponse();
-            if (json.has("multiValueExtendedProperties@odata.nextLink")) {
-                response.nextLink = json.get("multiValueExtendedProperties@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("multiValueExtendedProperties").toString(), JsonObject[].class);
-            final MultiValueLegacyExtendedProperty[] array = new MultiValueLegacyExtendedProperty[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), MultiValueLegacyExtendedProperty.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            multiValueExtendedProperties = new MultiValueLegacyExtendedPropertyCollectionPage(response, null);
+            multiValueExtendedProperties = serializer.deserializeObject(json.get("multiValueExtendedProperties").toString(), MultiValueLegacyExtendedPropertyCollectionPage.class);
         }
 
         if (json.has("singleValueExtendedProperties")) {
-            final SingleValueLegacyExtendedPropertyCollectionResponse response = new SingleValueLegacyExtendedPropertyCollectionResponse();
-            if (json.has("singleValueExtendedProperties@odata.nextLink")) {
-                response.nextLink = json.get("singleValueExtendedProperties@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("singleValueExtendedProperties").toString(), JsonObject[].class);
-            final SingleValueLegacyExtendedProperty[] array = new SingleValueLegacyExtendedProperty[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), SingleValueLegacyExtendedProperty.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            singleValueExtendedProperties = new SingleValueLegacyExtendedPropertyCollectionPage(response, null);
+            singleValueExtendedProperties = serializer.deserializeObject(json.get("singleValueExtendedProperties").toString(), SingleValueLegacyExtendedPropertyCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/ContentType.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ContentType.java
@@ -6,13 +6,11 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.ItemReference;
 import com.microsoft.graph.models.extensions.ContentTypeOrder;
 import com.microsoft.graph.models.extensions.ColumnLink;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.ColumnLinkCollectionResponse;
 import com.microsoft.graph.requests.extensions.ColumnLinkCollectionPage;
 
 
@@ -149,19 +147,7 @@ public class ContentType extends Entity implements IJsonBackedObject {
 
 
         if (json.has("columnLinks")) {
-            final ColumnLinkCollectionResponse response = new ColumnLinkCollectionResponse();
-            if (json.has("columnLinks@odata.nextLink")) {
-                response.nextLink = json.get("columnLinks@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("columnLinks").toString(), JsonObject[].class);
-            final ColumnLink[] array = new ColumnLink[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), ColumnLink.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            columnLinks = new ColumnLinkCollectionPage(response, null);
+            columnLinks = serializer.deserializeObject(json.get("columnLinks").toString(), ColumnLinkCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/ContentTypeInfo.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ContentTypeInfo.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ContentTypeOrder.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ContentTypeOrder.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/Contract.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Contract.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.DirectoryObject;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ControlScore.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ControlScore.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/Conversation.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Conversation.java
@@ -6,11 +6,9 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.ConversationThread;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.ConversationThreadCollectionResponse;
 import com.microsoft.graph.requests.extensions.ConversationThreadCollectionPage;
 
 
@@ -115,19 +113,7 @@ public class Conversation extends Entity implements IJsonBackedObject {
 
 
         if (json.has("threads")) {
-            final ConversationThreadCollectionResponse response = new ConversationThreadCollectionResponse();
-            if (json.has("threads@odata.nextLink")) {
-                response.nextLink = json.get("threads@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("threads").toString(), JsonObject[].class);
-            final ConversationThread[] array = new ConversationThread[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), ConversationThread.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            threads = new ConversationThreadCollectionPage(response, null);
+            threads = serializer.deserializeObject(json.get("threads").toString(), ConversationThreadCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/ConversationMember.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ConversationMember.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Entity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ConversationThread.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ConversationThread.java
@@ -6,12 +6,10 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Recipient;
 import com.microsoft.graph.models.extensions.Post;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.PostCollectionResponse;
 import com.microsoft.graph.requests.extensions.PostCollectionPage;
 
 
@@ -140,19 +138,7 @@ public class ConversationThread extends Entity implements IJsonBackedObject {
 
 
         if (json.has("posts")) {
-            final PostCollectionResponse response = new PostCollectionResponse();
-            if (json.has("posts@odata.nextLink")) {
-                response.nextLink = json.get("posts@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("posts").toString(), JsonObject[].class);
-            final Post[] array = new Post[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), Post.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            posts = new PostCollectionPage(response, null);
+            posts = serializer.deserializeObject(json.get("posts").toString(), PostCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/ConvertIdResult.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ConvertIdResult.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.GenericError;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/CopyNotebookModel.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/CopyNotebookModel.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.IdentitySet;
 import com.microsoft.graph.models.extensions.NotebookLinks;

--- a/src/main/java/com/microsoft/graph/models/extensions/CountryNamedLocation.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/CountryNamedLocation.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.NamedLocation;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/CurrencyColumn.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/CurrencyColumn.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/CustomTimeZone.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/CustomTimeZone.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.DaylightTimeZoneOffset;
 import com.microsoft.graph.models.extensions.StandardTimeZoneOffset;

--- a/src/main/java/com/microsoft/graph/models/extensions/DataPolicyOperation.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DataPolicyOperation.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.DataPolicyOperationStatus;
 import com.microsoft.graph.models.extensions.Entity;

--- a/src/main/java/com/microsoft/graph/models/extensions/DateTimeColumn.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DateTimeColumn.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/DateTimeTimeZone.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DateTimeTimeZone.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/DaylightTimeZoneOffset.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DaylightTimeZoneOffset.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.StandardTimeZoneOffset;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/DefaultColumnValue.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DefaultColumnValue.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/DefaultManagedAppProtection.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DefaultManagedAppProtection.java
@@ -6,14 +6,12 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.ManagedAppDataEncryptionType;
 import com.microsoft.graph.models.extensions.KeyValuePair;
 import com.microsoft.graph.models.extensions.ManagedMobileApp;
 import com.microsoft.graph.models.extensions.ManagedAppPolicyDeploymentSummary;
 import com.microsoft.graph.models.extensions.ManagedAppProtection;
-import com.microsoft.graph.requests.extensions.ManagedMobileAppCollectionResponse;
 import com.microsoft.graph.requests.extensions.ManagedMobileAppCollectionPage;
 
 
@@ -166,19 +164,7 @@ public class DefaultManagedAppProtection extends ManagedAppProtection implements
 
 
         if (json.has("apps")) {
-            final ManagedMobileAppCollectionResponse response = new ManagedMobileAppCollectionResponse();
-            if (json.has("apps@odata.nextLink")) {
-                response.nextLink = json.get("apps@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("apps").toString(), JsonObject[].class);
-            final ManagedMobileApp[] array = new ManagedMobileApp[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), ManagedMobileApp.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            apps = new ManagedMobileAppCollectionPage(response, null);
+            apps = serializer.deserializeObject(json.get("apps").toString(), ManagedMobileAppCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/DefenderDetectedMalwareActions.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DefenderDetectedMalwareActions.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.DefenderThreatAction;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/DelegatedPermissionClassification.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DelegatedPermissionClassification.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.PermissionClassificationType;
 import com.microsoft.graph.models.extensions.Entity;

--- a/src/main/java/com/microsoft/graph/models/extensions/DeleteUserFromSharedAppleDeviceActionResult.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DeleteUserFromSharedAppleDeviceActionResult.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.DeviceActionResult;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/Deleted.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Deleted.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/DetectedApp.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DetectedApp.java
@@ -6,11 +6,9 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.ManagedDevice;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.ManagedDeviceCollectionResponse;
 import com.microsoft.graph.requests.extensions.ManagedDeviceCollectionPage;
 
 
@@ -105,19 +103,7 @@ public class DetectedApp extends Entity implements IJsonBackedObject {
 
 
         if (json.has("managedDevices")) {
-            final ManagedDeviceCollectionResponse response = new ManagedDeviceCollectionResponse();
-            if (json.has("managedDevices@odata.nextLink")) {
-                response.nextLink = json.get("managedDevices@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("managedDevices").toString(), JsonObject[].class);
-            final ManagedDevice[] array = new ManagedDevice[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), ManagedDevice.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            managedDevices = new ManagedDeviceCollectionPage(response, null);
+            managedDevices = serializer.deserializeObject(json.get("managedDevices").toString(), ManagedDeviceCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/Device.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Device.java
@@ -6,14 +6,11 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.AlternativeSecurityId;
 import com.microsoft.graph.models.extensions.DirectoryObject;
 import com.microsoft.graph.models.extensions.Extension;
-import com.microsoft.graph.requests.extensions.DirectoryObjectCollectionResponse;
 import com.microsoft.graph.requests.extensions.DirectoryObjectCollectionPage;
-import com.microsoft.graph.requests.extensions.ExtensionCollectionResponse;
 import com.microsoft.graph.requests.extensions.ExtensionCollectionPage;
 
 
@@ -254,83 +251,23 @@ public class Device extends DirectoryObject implements IJsonBackedObject {
 
 
         if (json.has("memberOf")) {
-            final DirectoryObjectCollectionResponse response = new DirectoryObjectCollectionResponse();
-            if (json.has("memberOf@odata.nextLink")) {
-                response.nextLink = json.get("memberOf@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("memberOf").toString(), JsonObject[].class);
-            final DirectoryObject[] array = new DirectoryObject[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DirectoryObject.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            memberOf = new DirectoryObjectCollectionPage(response, null);
+            memberOf = serializer.deserializeObject(json.get("memberOf").toString(), DirectoryObjectCollectionPage.class);
         }
 
         if (json.has("registeredOwners")) {
-            final DirectoryObjectCollectionResponse response = new DirectoryObjectCollectionResponse();
-            if (json.has("registeredOwners@odata.nextLink")) {
-                response.nextLink = json.get("registeredOwners@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("registeredOwners").toString(), JsonObject[].class);
-            final DirectoryObject[] array = new DirectoryObject[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DirectoryObject.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            registeredOwners = new DirectoryObjectCollectionPage(response, null);
+            registeredOwners = serializer.deserializeObject(json.get("registeredOwners").toString(), DirectoryObjectCollectionPage.class);
         }
 
         if (json.has("registeredUsers")) {
-            final DirectoryObjectCollectionResponse response = new DirectoryObjectCollectionResponse();
-            if (json.has("registeredUsers@odata.nextLink")) {
-                response.nextLink = json.get("registeredUsers@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("registeredUsers").toString(), JsonObject[].class);
-            final DirectoryObject[] array = new DirectoryObject[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DirectoryObject.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            registeredUsers = new DirectoryObjectCollectionPage(response, null);
+            registeredUsers = serializer.deserializeObject(json.get("registeredUsers").toString(), DirectoryObjectCollectionPage.class);
         }
 
         if (json.has("transitiveMemberOf")) {
-            final DirectoryObjectCollectionResponse response = new DirectoryObjectCollectionResponse();
-            if (json.has("transitiveMemberOf@odata.nextLink")) {
-                response.nextLink = json.get("transitiveMemberOf@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("transitiveMemberOf").toString(), JsonObject[].class);
-            final DirectoryObject[] array = new DirectoryObject[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DirectoryObject.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            transitiveMemberOf = new DirectoryObjectCollectionPage(response, null);
+            transitiveMemberOf = serializer.deserializeObject(json.get("transitiveMemberOf").toString(), DirectoryObjectCollectionPage.class);
         }
 
         if (json.has("extensions")) {
-            final ExtensionCollectionResponse response = new ExtensionCollectionResponse();
-            if (json.has("extensions@odata.nextLink")) {
-                response.nextLink = json.get("extensions@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("extensions").toString(), JsonObject[].class);
-            final Extension[] array = new Extension[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), Extension.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            extensions = new ExtensionCollectionPage(response, null);
+            extensions = serializer.deserializeObject(json.get("extensions").toString(), ExtensionCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/DeviceActionResult.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DeviceActionResult.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.ActionState;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/DeviceAndAppManagementAssignmentTarget.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DeviceAndAppManagementAssignmentTarget.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/DeviceAndAppManagementRoleAssignment.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DeviceAndAppManagementRoleAssignment.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.RoleAssignment;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/DeviceAndAppManagementRoleDefinition.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DeviceAndAppManagementRoleDefinition.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.RoleDefinition;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/DeviceAppManagement.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DeviceAppManagement.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.ManagedEBook;
 import com.microsoft.graph.models.extensions.MobileAppCategory;
@@ -23,33 +22,19 @@ import com.microsoft.graph.models.extensions.MdmWindowsInformationProtectionPoli
 import com.microsoft.graph.models.extensions.TargetedManagedAppConfiguration;
 import com.microsoft.graph.models.extensions.WindowsInformationProtectionPolicy;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.ManagedEBookCollectionResponse;
 import com.microsoft.graph.requests.extensions.ManagedEBookCollectionPage;
-import com.microsoft.graph.requests.extensions.MobileAppCategoryCollectionResponse;
 import com.microsoft.graph.requests.extensions.MobileAppCategoryCollectionPage;
-import com.microsoft.graph.requests.extensions.ManagedDeviceMobileAppConfigurationCollectionResponse;
 import com.microsoft.graph.requests.extensions.ManagedDeviceMobileAppConfigurationCollectionPage;
-import com.microsoft.graph.requests.extensions.MobileAppCollectionResponse;
 import com.microsoft.graph.requests.extensions.MobileAppCollectionPage;
-import com.microsoft.graph.requests.extensions.VppTokenCollectionResponse;
 import com.microsoft.graph.requests.extensions.VppTokenCollectionPage;
-import com.microsoft.graph.requests.extensions.AndroidManagedAppProtectionCollectionResponse;
 import com.microsoft.graph.requests.extensions.AndroidManagedAppProtectionCollectionPage;
-import com.microsoft.graph.requests.extensions.DefaultManagedAppProtectionCollectionResponse;
 import com.microsoft.graph.requests.extensions.DefaultManagedAppProtectionCollectionPage;
-import com.microsoft.graph.requests.extensions.IosManagedAppProtectionCollectionResponse;
 import com.microsoft.graph.requests.extensions.IosManagedAppProtectionCollectionPage;
-import com.microsoft.graph.requests.extensions.ManagedAppPolicyCollectionResponse;
 import com.microsoft.graph.requests.extensions.ManagedAppPolicyCollectionPage;
-import com.microsoft.graph.requests.extensions.ManagedAppRegistrationCollectionResponse;
 import com.microsoft.graph.requests.extensions.ManagedAppRegistrationCollectionPage;
-import com.microsoft.graph.requests.extensions.ManagedAppStatusCollectionResponse;
 import com.microsoft.graph.requests.extensions.ManagedAppStatusCollectionPage;
-import com.microsoft.graph.requests.extensions.MdmWindowsInformationProtectionPolicyCollectionResponse;
 import com.microsoft.graph.requests.extensions.MdmWindowsInformationProtectionPolicyCollectionPage;
-import com.microsoft.graph.requests.extensions.TargetedManagedAppConfigurationCollectionResponse;
 import com.microsoft.graph.requests.extensions.TargetedManagedAppConfigurationCollectionPage;
-import com.microsoft.graph.requests.extensions.WindowsInformationProtectionPolicyCollectionResponse;
 import com.microsoft.graph.requests.extensions.WindowsInformationProtectionPolicyCollectionPage;
 
 
@@ -250,227 +235,59 @@ public class DeviceAppManagement extends Entity implements IJsonBackedObject {
 
 
         if (json.has("managedEBooks")) {
-            final ManagedEBookCollectionResponse response = new ManagedEBookCollectionResponse();
-            if (json.has("managedEBooks@odata.nextLink")) {
-                response.nextLink = json.get("managedEBooks@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("managedEBooks").toString(), JsonObject[].class);
-            final ManagedEBook[] array = new ManagedEBook[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), ManagedEBook.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            managedEBooks = new ManagedEBookCollectionPage(response, null);
+            managedEBooks = serializer.deserializeObject(json.get("managedEBooks").toString(), ManagedEBookCollectionPage.class);
         }
 
         if (json.has("mobileAppCategories")) {
-            final MobileAppCategoryCollectionResponse response = new MobileAppCategoryCollectionResponse();
-            if (json.has("mobileAppCategories@odata.nextLink")) {
-                response.nextLink = json.get("mobileAppCategories@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("mobileAppCategories").toString(), JsonObject[].class);
-            final MobileAppCategory[] array = new MobileAppCategory[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), MobileAppCategory.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            mobileAppCategories = new MobileAppCategoryCollectionPage(response, null);
+            mobileAppCategories = serializer.deserializeObject(json.get("mobileAppCategories").toString(), MobileAppCategoryCollectionPage.class);
         }
 
         if (json.has("mobileAppConfigurations")) {
-            final ManagedDeviceMobileAppConfigurationCollectionResponse response = new ManagedDeviceMobileAppConfigurationCollectionResponse();
-            if (json.has("mobileAppConfigurations@odata.nextLink")) {
-                response.nextLink = json.get("mobileAppConfigurations@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("mobileAppConfigurations").toString(), JsonObject[].class);
-            final ManagedDeviceMobileAppConfiguration[] array = new ManagedDeviceMobileAppConfiguration[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), ManagedDeviceMobileAppConfiguration.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            mobileAppConfigurations = new ManagedDeviceMobileAppConfigurationCollectionPage(response, null);
+            mobileAppConfigurations = serializer.deserializeObject(json.get("mobileAppConfigurations").toString(), ManagedDeviceMobileAppConfigurationCollectionPage.class);
         }
 
         if (json.has("mobileApps")) {
-            final MobileAppCollectionResponse response = new MobileAppCollectionResponse();
-            if (json.has("mobileApps@odata.nextLink")) {
-                response.nextLink = json.get("mobileApps@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("mobileApps").toString(), JsonObject[].class);
-            final MobileApp[] array = new MobileApp[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), MobileApp.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            mobileApps = new MobileAppCollectionPage(response, null);
+            mobileApps = serializer.deserializeObject(json.get("mobileApps").toString(), MobileAppCollectionPage.class);
         }
 
         if (json.has("vppTokens")) {
-            final VppTokenCollectionResponse response = new VppTokenCollectionResponse();
-            if (json.has("vppTokens@odata.nextLink")) {
-                response.nextLink = json.get("vppTokens@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("vppTokens").toString(), JsonObject[].class);
-            final VppToken[] array = new VppToken[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), VppToken.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            vppTokens = new VppTokenCollectionPage(response, null);
+            vppTokens = serializer.deserializeObject(json.get("vppTokens").toString(), VppTokenCollectionPage.class);
         }
 
         if (json.has("androidManagedAppProtections")) {
-            final AndroidManagedAppProtectionCollectionResponse response = new AndroidManagedAppProtectionCollectionResponse();
-            if (json.has("androidManagedAppProtections@odata.nextLink")) {
-                response.nextLink = json.get("androidManagedAppProtections@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("androidManagedAppProtections").toString(), JsonObject[].class);
-            final AndroidManagedAppProtection[] array = new AndroidManagedAppProtection[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), AndroidManagedAppProtection.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            androidManagedAppProtections = new AndroidManagedAppProtectionCollectionPage(response, null);
+            androidManagedAppProtections = serializer.deserializeObject(json.get("androidManagedAppProtections").toString(), AndroidManagedAppProtectionCollectionPage.class);
         }
 
         if (json.has("defaultManagedAppProtections")) {
-            final DefaultManagedAppProtectionCollectionResponse response = new DefaultManagedAppProtectionCollectionResponse();
-            if (json.has("defaultManagedAppProtections@odata.nextLink")) {
-                response.nextLink = json.get("defaultManagedAppProtections@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("defaultManagedAppProtections").toString(), JsonObject[].class);
-            final DefaultManagedAppProtection[] array = new DefaultManagedAppProtection[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DefaultManagedAppProtection.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            defaultManagedAppProtections = new DefaultManagedAppProtectionCollectionPage(response, null);
+            defaultManagedAppProtections = serializer.deserializeObject(json.get("defaultManagedAppProtections").toString(), DefaultManagedAppProtectionCollectionPage.class);
         }
 
         if (json.has("iosManagedAppProtections")) {
-            final IosManagedAppProtectionCollectionResponse response = new IosManagedAppProtectionCollectionResponse();
-            if (json.has("iosManagedAppProtections@odata.nextLink")) {
-                response.nextLink = json.get("iosManagedAppProtections@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("iosManagedAppProtections").toString(), JsonObject[].class);
-            final IosManagedAppProtection[] array = new IosManagedAppProtection[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), IosManagedAppProtection.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            iosManagedAppProtections = new IosManagedAppProtectionCollectionPage(response, null);
+            iosManagedAppProtections = serializer.deserializeObject(json.get("iosManagedAppProtections").toString(), IosManagedAppProtectionCollectionPage.class);
         }
 
         if (json.has("managedAppPolicies")) {
-            final ManagedAppPolicyCollectionResponse response = new ManagedAppPolicyCollectionResponse();
-            if (json.has("managedAppPolicies@odata.nextLink")) {
-                response.nextLink = json.get("managedAppPolicies@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("managedAppPolicies").toString(), JsonObject[].class);
-            final ManagedAppPolicy[] array = new ManagedAppPolicy[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), ManagedAppPolicy.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            managedAppPolicies = new ManagedAppPolicyCollectionPage(response, null);
+            managedAppPolicies = serializer.deserializeObject(json.get("managedAppPolicies").toString(), ManagedAppPolicyCollectionPage.class);
         }
 
         if (json.has("managedAppRegistrations")) {
-            final ManagedAppRegistrationCollectionResponse response = new ManagedAppRegistrationCollectionResponse();
-            if (json.has("managedAppRegistrations@odata.nextLink")) {
-                response.nextLink = json.get("managedAppRegistrations@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("managedAppRegistrations").toString(), JsonObject[].class);
-            final ManagedAppRegistration[] array = new ManagedAppRegistration[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), ManagedAppRegistration.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            managedAppRegistrations = new ManagedAppRegistrationCollectionPage(response, null);
+            managedAppRegistrations = serializer.deserializeObject(json.get("managedAppRegistrations").toString(), ManagedAppRegistrationCollectionPage.class);
         }
 
         if (json.has("managedAppStatuses")) {
-            final ManagedAppStatusCollectionResponse response = new ManagedAppStatusCollectionResponse();
-            if (json.has("managedAppStatuses@odata.nextLink")) {
-                response.nextLink = json.get("managedAppStatuses@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("managedAppStatuses").toString(), JsonObject[].class);
-            final ManagedAppStatus[] array = new ManagedAppStatus[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), ManagedAppStatus.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            managedAppStatuses = new ManagedAppStatusCollectionPage(response, null);
+            managedAppStatuses = serializer.deserializeObject(json.get("managedAppStatuses").toString(), ManagedAppStatusCollectionPage.class);
         }
 
         if (json.has("mdmWindowsInformationProtectionPolicies")) {
-            final MdmWindowsInformationProtectionPolicyCollectionResponse response = new MdmWindowsInformationProtectionPolicyCollectionResponse();
-            if (json.has("mdmWindowsInformationProtectionPolicies@odata.nextLink")) {
-                response.nextLink = json.get("mdmWindowsInformationProtectionPolicies@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("mdmWindowsInformationProtectionPolicies").toString(), JsonObject[].class);
-            final MdmWindowsInformationProtectionPolicy[] array = new MdmWindowsInformationProtectionPolicy[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), MdmWindowsInformationProtectionPolicy.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            mdmWindowsInformationProtectionPolicies = new MdmWindowsInformationProtectionPolicyCollectionPage(response, null);
+            mdmWindowsInformationProtectionPolicies = serializer.deserializeObject(json.get("mdmWindowsInformationProtectionPolicies").toString(), MdmWindowsInformationProtectionPolicyCollectionPage.class);
         }
 
         if (json.has("targetedManagedAppConfigurations")) {
-            final TargetedManagedAppConfigurationCollectionResponse response = new TargetedManagedAppConfigurationCollectionResponse();
-            if (json.has("targetedManagedAppConfigurations@odata.nextLink")) {
-                response.nextLink = json.get("targetedManagedAppConfigurations@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("targetedManagedAppConfigurations").toString(), JsonObject[].class);
-            final TargetedManagedAppConfiguration[] array = new TargetedManagedAppConfiguration[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), TargetedManagedAppConfiguration.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            targetedManagedAppConfigurations = new TargetedManagedAppConfigurationCollectionPage(response, null);
+            targetedManagedAppConfigurations = serializer.deserializeObject(json.get("targetedManagedAppConfigurations").toString(), TargetedManagedAppConfigurationCollectionPage.class);
         }
 
         if (json.has("windowsInformationProtectionPolicies")) {
-            final WindowsInformationProtectionPolicyCollectionResponse response = new WindowsInformationProtectionPolicyCollectionResponse();
-            if (json.has("windowsInformationProtectionPolicies@odata.nextLink")) {
-                response.nextLink = json.get("windowsInformationProtectionPolicies@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("windowsInformationProtectionPolicies").toString(), JsonObject[].class);
-            final WindowsInformationProtectionPolicy[] array = new WindowsInformationProtectionPolicy[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), WindowsInformationProtectionPolicy.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            windowsInformationProtectionPolicies = new WindowsInformationProtectionPolicyCollectionPage(response, null);
+            windowsInformationProtectionPolicies = serializer.deserializeObject(json.get("windowsInformationProtectionPolicies").toString(), WindowsInformationProtectionPolicyCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/DeviceCategory.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DeviceCategory.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Entity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/DeviceComplianceActionItem.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DeviceComplianceActionItem.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.DeviceComplianceActionType;
 import com.microsoft.graph.models.extensions.Entity;

--- a/src/main/java/com/microsoft/graph/models/extensions/DeviceComplianceDeviceOverview.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DeviceComplianceDeviceOverview.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Entity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/DeviceComplianceDeviceStatus.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DeviceComplianceDeviceStatus.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.ComplianceStatus;
 import com.microsoft.graph.models.extensions.Entity;

--- a/src/main/java/com/microsoft/graph/models/extensions/DeviceCompliancePolicy.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DeviceCompliancePolicy.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.DeviceCompliancePolicyAssignment;
 import com.microsoft.graph.models.extensions.SettingStateDeviceSummary;
@@ -16,15 +15,10 @@ import com.microsoft.graph.models.extensions.DeviceComplianceScheduledActionForR
 import com.microsoft.graph.models.extensions.DeviceComplianceUserStatus;
 import com.microsoft.graph.models.extensions.DeviceComplianceUserOverview;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.DeviceCompliancePolicyAssignmentCollectionResponse;
 import com.microsoft.graph.requests.extensions.DeviceCompliancePolicyAssignmentCollectionPage;
-import com.microsoft.graph.requests.extensions.SettingStateDeviceSummaryCollectionResponse;
 import com.microsoft.graph.requests.extensions.SettingStateDeviceSummaryCollectionPage;
-import com.microsoft.graph.requests.extensions.DeviceComplianceDeviceStatusCollectionResponse;
 import com.microsoft.graph.requests.extensions.DeviceComplianceDeviceStatusCollectionPage;
-import com.microsoft.graph.requests.extensions.DeviceComplianceScheduledActionForRuleCollectionResponse;
 import com.microsoft.graph.requests.extensions.DeviceComplianceScheduledActionForRuleCollectionPage;
-import com.microsoft.graph.requests.extensions.DeviceComplianceUserStatusCollectionResponse;
 import com.microsoft.graph.requests.extensions.DeviceComplianceUserStatusCollectionPage;
 
 
@@ -177,83 +171,23 @@ public class DeviceCompliancePolicy extends Entity implements IJsonBackedObject 
 
 
         if (json.has("assignments")) {
-            final DeviceCompliancePolicyAssignmentCollectionResponse response = new DeviceCompliancePolicyAssignmentCollectionResponse();
-            if (json.has("assignments@odata.nextLink")) {
-                response.nextLink = json.get("assignments@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("assignments").toString(), JsonObject[].class);
-            final DeviceCompliancePolicyAssignment[] array = new DeviceCompliancePolicyAssignment[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DeviceCompliancePolicyAssignment.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            assignments = new DeviceCompliancePolicyAssignmentCollectionPage(response, null);
+            assignments = serializer.deserializeObject(json.get("assignments").toString(), DeviceCompliancePolicyAssignmentCollectionPage.class);
         }
 
         if (json.has("deviceSettingStateSummaries")) {
-            final SettingStateDeviceSummaryCollectionResponse response = new SettingStateDeviceSummaryCollectionResponse();
-            if (json.has("deviceSettingStateSummaries@odata.nextLink")) {
-                response.nextLink = json.get("deviceSettingStateSummaries@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("deviceSettingStateSummaries").toString(), JsonObject[].class);
-            final SettingStateDeviceSummary[] array = new SettingStateDeviceSummary[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), SettingStateDeviceSummary.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            deviceSettingStateSummaries = new SettingStateDeviceSummaryCollectionPage(response, null);
+            deviceSettingStateSummaries = serializer.deserializeObject(json.get("deviceSettingStateSummaries").toString(), SettingStateDeviceSummaryCollectionPage.class);
         }
 
         if (json.has("deviceStatuses")) {
-            final DeviceComplianceDeviceStatusCollectionResponse response = new DeviceComplianceDeviceStatusCollectionResponse();
-            if (json.has("deviceStatuses@odata.nextLink")) {
-                response.nextLink = json.get("deviceStatuses@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("deviceStatuses").toString(), JsonObject[].class);
-            final DeviceComplianceDeviceStatus[] array = new DeviceComplianceDeviceStatus[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DeviceComplianceDeviceStatus.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            deviceStatuses = new DeviceComplianceDeviceStatusCollectionPage(response, null);
+            deviceStatuses = serializer.deserializeObject(json.get("deviceStatuses").toString(), DeviceComplianceDeviceStatusCollectionPage.class);
         }
 
         if (json.has("scheduledActionsForRule")) {
-            final DeviceComplianceScheduledActionForRuleCollectionResponse response = new DeviceComplianceScheduledActionForRuleCollectionResponse();
-            if (json.has("scheduledActionsForRule@odata.nextLink")) {
-                response.nextLink = json.get("scheduledActionsForRule@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("scheduledActionsForRule").toString(), JsonObject[].class);
-            final DeviceComplianceScheduledActionForRule[] array = new DeviceComplianceScheduledActionForRule[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DeviceComplianceScheduledActionForRule.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            scheduledActionsForRule = new DeviceComplianceScheduledActionForRuleCollectionPage(response, null);
+            scheduledActionsForRule = serializer.deserializeObject(json.get("scheduledActionsForRule").toString(), DeviceComplianceScheduledActionForRuleCollectionPage.class);
         }
 
         if (json.has("userStatuses")) {
-            final DeviceComplianceUserStatusCollectionResponse response = new DeviceComplianceUserStatusCollectionResponse();
-            if (json.has("userStatuses@odata.nextLink")) {
-                response.nextLink = json.get("userStatuses@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("userStatuses").toString(), JsonObject[].class);
-            final DeviceComplianceUserStatus[] array = new DeviceComplianceUserStatus[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DeviceComplianceUserStatus.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            userStatuses = new DeviceComplianceUserStatusCollectionPage(response, null);
+            userStatuses = serializer.deserializeObject(json.get("userStatuses").toString(), DeviceComplianceUserStatusCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/DeviceCompliancePolicyAssignment.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DeviceCompliancePolicyAssignment.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.DeviceAndAppManagementAssignmentTarget;
 import com.microsoft.graph.models.extensions.Entity;

--- a/src/main/java/com/microsoft/graph/models/extensions/DeviceCompliancePolicyDeviceStateSummary.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DeviceCompliancePolicyDeviceStateSummary.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Entity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/DeviceCompliancePolicySettingState.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DeviceCompliancePolicySettingState.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.SettingSource;
 import com.microsoft.graph.models.generated.ComplianceStatus;

--- a/src/main/java/com/microsoft/graph/models/extensions/DeviceCompliancePolicySettingStateSummary.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DeviceCompliancePolicySettingStateSummary.java
@@ -6,12 +6,10 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.PolicyPlatformType;
 import com.microsoft.graph.models.extensions.DeviceComplianceSettingState;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.DeviceComplianceSettingStateCollectionResponse;
 import com.microsoft.graph.requests.extensions.DeviceComplianceSettingStateCollectionPage;
 
 
@@ -156,19 +154,7 @@ public class DeviceCompliancePolicySettingStateSummary extends Entity implements
 
 
         if (json.has("deviceComplianceSettingStates")) {
-            final DeviceComplianceSettingStateCollectionResponse response = new DeviceComplianceSettingStateCollectionResponse();
-            if (json.has("deviceComplianceSettingStates@odata.nextLink")) {
-                response.nextLink = json.get("deviceComplianceSettingStates@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("deviceComplianceSettingStates").toString(), JsonObject[].class);
-            final DeviceComplianceSettingState[] array = new DeviceComplianceSettingState[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DeviceComplianceSettingState.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            deviceComplianceSettingStates = new DeviceComplianceSettingStateCollectionPage(response, null);
+            deviceComplianceSettingStates = serializer.deserializeObject(json.get("deviceComplianceSettingStates").toString(), DeviceComplianceSettingStateCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/DeviceCompliancePolicyState.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DeviceCompliancePolicyState.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.PolicyPlatformType;
 import com.microsoft.graph.models.extensions.DeviceCompliancePolicySettingState;

--- a/src/main/java/com/microsoft/graph/models/extensions/DeviceComplianceScheduledActionForRule.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DeviceComplianceScheduledActionForRule.java
@@ -6,11 +6,9 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.DeviceComplianceActionItem;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.DeviceComplianceActionItemCollectionResponse;
 import com.microsoft.graph.requests.extensions.DeviceComplianceActionItemCollectionPage;
 
 
@@ -83,19 +81,7 @@ public class DeviceComplianceScheduledActionForRule extends Entity implements IJ
 
 
         if (json.has("scheduledActionConfigurations")) {
-            final DeviceComplianceActionItemCollectionResponse response = new DeviceComplianceActionItemCollectionResponse();
-            if (json.has("scheduledActionConfigurations@odata.nextLink")) {
-                response.nextLink = json.get("scheduledActionConfigurations@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("scheduledActionConfigurations").toString(), JsonObject[].class);
-            final DeviceComplianceActionItem[] array = new DeviceComplianceActionItem[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DeviceComplianceActionItem.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            scheduledActionConfigurations = new DeviceComplianceActionItemCollectionPage(response, null);
+            scheduledActionConfigurations = serializer.deserializeObject(json.get("scheduledActionConfigurations").toString(), DeviceComplianceActionItemCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/DeviceComplianceSettingState.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DeviceComplianceSettingState.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.ComplianceStatus;
 import com.microsoft.graph.models.extensions.Entity;

--- a/src/main/java/com/microsoft/graph/models/extensions/DeviceComplianceUserOverview.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DeviceComplianceUserOverview.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Entity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/DeviceComplianceUserStatus.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DeviceComplianceUserStatus.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.ComplianceStatus;
 import com.microsoft.graph.models.extensions.Entity;

--- a/src/main/java/com/microsoft/graph/models/extensions/DeviceConfiguration.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DeviceConfiguration.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.DeviceConfigurationAssignment;
 import com.microsoft.graph.models.extensions.SettingStateDeviceSummary;
@@ -15,13 +14,9 @@ import com.microsoft.graph.models.extensions.DeviceConfigurationDeviceOverview;
 import com.microsoft.graph.models.extensions.DeviceConfigurationUserStatus;
 import com.microsoft.graph.models.extensions.DeviceConfigurationUserOverview;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.DeviceConfigurationAssignmentCollectionResponse;
 import com.microsoft.graph.requests.extensions.DeviceConfigurationAssignmentCollectionPage;
-import com.microsoft.graph.requests.extensions.SettingStateDeviceSummaryCollectionResponse;
 import com.microsoft.graph.requests.extensions.SettingStateDeviceSummaryCollectionPage;
-import com.microsoft.graph.requests.extensions.DeviceConfigurationDeviceStatusCollectionResponse;
 import com.microsoft.graph.requests.extensions.DeviceConfigurationDeviceStatusCollectionPage;
-import com.microsoft.graph.requests.extensions.DeviceConfigurationUserStatusCollectionResponse;
 import com.microsoft.graph.requests.extensions.DeviceConfigurationUserStatusCollectionPage;
 
 
@@ -166,67 +161,19 @@ public class DeviceConfiguration extends Entity implements IJsonBackedObject {
 
 
         if (json.has("assignments")) {
-            final DeviceConfigurationAssignmentCollectionResponse response = new DeviceConfigurationAssignmentCollectionResponse();
-            if (json.has("assignments@odata.nextLink")) {
-                response.nextLink = json.get("assignments@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("assignments").toString(), JsonObject[].class);
-            final DeviceConfigurationAssignment[] array = new DeviceConfigurationAssignment[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DeviceConfigurationAssignment.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            assignments = new DeviceConfigurationAssignmentCollectionPage(response, null);
+            assignments = serializer.deserializeObject(json.get("assignments").toString(), DeviceConfigurationAssignmentCollectionPage.class);
         }
 
         if (json.has("deviceSettingStateSummaries")) {
-            final SettingStateDeviceSummaryCollectionResponse response = new SettingStateDeviceSummaryCollectionResponse();
-            if (json.has("deviceSettingStateSummaries@odata.nextLink")) {
-                response.nextLink = json.get("deviceSettingStateSummaries@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("deviceSettingStateSummaries").toString(), JsonObject[].class);
-            final SettingStateDeviceSummary[] array = new SettingStateDeviceSummary[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), SettingStateDeviceSummary.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            deviceSettingStateSummaries = new SettingStateDeviceSummaryCollectionPage(response, null);
+            deviceSettingStateSummaries = serializer.deserializeObject(json.get("deviceSettingStateSummaries").toString(), SettingStateDeviceSummaryCollectionPage.class);
         }
 
         if (json.has("deviceStatuses")) {
-            final DeviceConfigurationDeviceStatusCollectionResponse response = new DeviceConfigurationDeviceStatusCollectionResponse();
-            if (json.has("deviceStatuses@odata.nextLink")) {
-                response.nextLink = json.get("deviceStatuses@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("deviceStatuses").toString(), JsonObject[].class);
-            final DeviceConfigurationDeviceStatus[] array = new DeviceConfigurationDeviceStatus[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DeviceConfigurationDeviceStatus.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            deviceStatuses = new DeviceConfigurationDeviceStatusCollectionPage(response, null);
+            deviceStatuses = serializer.deserializeObject(json.get("deviceStatuses").toString(), DeviceConfigurationDeviceStatusCollectionPage.class);
         }
 
         if (json.has("userStatuses")) {
-            final DeviceConfigurationUserStatusCollectionResponse response = new DeviceConfigurationUserStatusCollectionResponse();
-            if (json.has("userStatuses@odata.nextLink")) {
-                response.nextLink = json.get("userStatuses@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("userStatuses").toString(), JsonObject[].class);
-            final DeviceConfigurationUserStatus[] array = new DeviceConfigurationUserStatus[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DeviceConfigurationUserStatus.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            userStatuses = new DeviceConfigurationUserStatusCollectionPage(response, null);
+            userStatuses = serializer.deserializeObject(json.get("userStatuses").toString(), DeviceConfigurationUserStatusCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/DeviceConfigurationAssignment.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DeviceConfigurationAssignment.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.DeviceAndAppManagementAssignmentTarget;
 import com.microsoft.graph.models.extensions.Entity;

--- a/src/main/java/com/microsoft/graph/models/extensions/DeviceConfigurationDeviceOverview.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DeviceConfigurationDeviceOverview.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Entity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/DeviceConfigurationDeviceStateSummary.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DeviceConfigurationDeviceStateSummary.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Entity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/DeviceConfigurationDeviceStatus.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DeviceConfigurationDeviceStatus.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.ComplianceStatus;
 import com.microsoft.graph.models.extensions.Entity;

--- a/src/main/java/com/microsoft/graph/models/extensions/DeviceConfigurationSettingState.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DeviceConfigurationSettingState.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.SettingSource;
 import com.microsoft.graph.models.generated.ComplianceStatus;

--- a/src/main/java/com/microsoft/graph/models/extensions/DeviceConfigurationState.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DeviceConfigurationState.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.PolicyPlatformType;
 import com.microsoft.graph.models.extensions.DeviceConfigurationSettingState;

--- a/src/main/java/com/microsoft/graph/models/extensions/DeviceConfigurationUserOverview.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DeviceConfigurationUserOverview.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Entity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/DeviceConfigurationUserStatus.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DeviceConfigurationUserStatus.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.ComplianceStatus;
 import com.microsoft.graph.models.extensions.Entity;

--- a/src/main/java/com/microsoft/graph/models/extensions/DeviceDetail.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DeviceDetail.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/DeviceEnrollmentConfiguration.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DeviceEnrollmentConfiguration.java
@@ -6,11 +6,9 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.EnrollmentConfigurationAssignment;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.EnrollmentConfigurationAssignmentCollectionResponse;
 import com.microsoft.graph.requests.extensions.EnrollmentConfigurationAssignmentCollectionPage;
 
 
@@ -123,19 +121,7 @@ public class DeviceEnrollmentConfiguration extends Entity implements IJsonBacked
 
 
         if (json.has("assignments")) {
-            final EnrollmentConfigurationAssignmentCollectionResponse response = new EnrollmentConfigurationAssignmentCollectionResponse();
-            if (json.has("assignments@odata.nextLink")) {
-                response.nextLink = json.get("assignments@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("assignments").toString(), JsonObject[].class);
-            final EnrollmentConfigurationAssignment[] array = new EnrollmentConfigurationAssignment[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), EnrollmentConfigurationAssignment.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            assignments = new EnrollmentConfigurationAssignmentCollectionPage(response, null);
+            assignments = serializer.deserializeObject(json.get("assignments").toString(), EnrollmentConfigurationAssignmentCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/DeviceEnrollmentLimitConfiguration.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DeviceEnrollmentLimitConfiguration.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.DeviceEnrollmentConfiguration;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/DeviceEnrollmentPlatformRestriction.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DeviceEnrollmentPlatformRestriction.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/DeviceEnrollmentPlatformRestrictionsConfiguration.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DeviceEnrollmentPlatformRestrictionsConfiguration.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.DeviceEnrollmentPlatformRestriction;
 import com.microsoft.graph.models.extensions.DeviceEnrollmentConfiguration;

--- a/src/main/java/com/microsoft/graph/models/extensions/DeviceEnrollmentWindowsHelloForBusinessConfiguration.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DeviceEnrollmentWindowsHelloForBusinessConfiguration.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.Enablement;
 import com.microsoft.graph.models.generated.WindowsHelloForBusinessPinUsage;

--- a/src/main/java/com/microsoft/graph/models/extensions/DeviceExchangeAccessStateSummary.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DeviceExchangeAccessStateSummary.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/DeviceGeoLocation.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DeviceGeoLocation.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/DeviceHealthAttestationState.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DeviceHealthAttestationState.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/DeviceInstallState.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DeviceInstallState.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.InstallState;
 import com.microsoft.graph.models.extensions.Entity;

--- a/src/main/java/com/microsoft/graph/models/extensions/DeviceManagement.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DeviceManagement.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.DeviceManagementSettings;
 import com.microsoft.graph.models.extensions.IntuneBrand;
@@ -40,49 +39,27 @@ import com.microsoft.graph.models.extensions.DeviceManagementTroubleshootingEven
 import com.microsoft.graph.models.extensions.WindowsInformationProtectionAppLearningSummary;
 import com.microsoft.graph.models.extensions.WindowsInformationProtectionNetworkLearningSummary;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.TermsAndConditionsCollectionResponse;
 import com.microsoft.graph.requests.extensions.TermsAndConditionsCollectionPage;
-import com.microsoft.graph.requests.extensions.DeviceCompliancePolicyCollectionResponse;
 import com.microsoft.graph.requests.extensions.DeviceCompliancePolicyCollectionPage;
-import com.microsoft.graph.requests.extensions.DeviceCompliancePolicySettingStateSummaryCollectionResponse;
 import com.microsoft.graph.requests.extensions.DeviceCompliancePolicySettingStateSummaryCollectionPage;
-import com.microsoft.graph.requests.extensions.DeviceConfigurationCollectionResponse;
 import com.microsoft.graph.requests.extensions.DeviceConfigurationCollectionPage;
-import com.microsoft.graph.requests.extensions.IosUpdateDeviceStatusCollectionResponse;
 import com.microsoft.graph.requests.extensions.IosUpdateDeviceStatusCollectionPage;
-import com.microsoft.graph.requests.extensions.ComplianceManagementPartnerCollectionResponse;
 import com.microsoft.graph.requests.extensions.ComplianceManagementPartnerCollectionPage;
-import com.microsoft.graph.requests.extensions.DeviceCategoryCollectionResponse;
 import com.microsoft.graph.requests.extensions.DeviceCategoryCollectionPage;
-import com.microsoft.graph.requests.extensions.DeviceEnrollmentConfigurationCollectionResponse;
 import com.microsoft.graph.requests.extensions.DeviceEnrollmentConfigurationCollectionPage;
-import com.microsoft.graph.requests.extensions.DeviceManagementPartnerCollectionResponse;
 import com.microsoft.graph.requests.extensions.DeviceManagementPartnerCollectionPage;
-import com.microsoft.graph.requests.extensions.DeviceManagementExchangeConnectorCollectionResponse;
 import com.microsoft.graph.requests.extensions.DeviceManagementExchangeConnectorCollectionPage;
-import com.microsoft.graph.requests.extensions.MobileThreatDefenseConnectorCollectionResponse;
 import com.microsoft.graph.requests.extensions.MobileThreatDefenseConnectorCollectionPage;
-import com.microsoft.graph.requests.extensions.DetectedAppCollectionResponse;
 import com.microsoft.graph.requests.extensions.DetectedAppCollectionPage;
-import com.microsoft.graph.requests.extensions.ManagedDeviceCollectionResponse;
 import com.microsoft.graph.requests.extensions.ManagedDeviceCollectionPage;
-import com.microsoft.graph.requests.extensions.NotificationMessageTemplateCollectionResponse;
 import com.microsoft.graph.requests.extensions.NotificationMessageTemplateCollectionPage;
-import com.microsoft.graph.requests.extensions.ResourceOperationCollectionResponse;
 import com.microsoft.graph.requests.extensions.ResourceOperationCollectionPage;
-import com.microsoft.graph.requests.extensions.DeviceAndAppManagementRoleAssignmentCollectionResponse;
 import com.microsoft.graph.requests.extensions.DeviceAndAppManagementRoleAssignmentCollectionPage;
-import com.microsoft.graph.requests.extensions.RoleDefinitionCollectionResponse;
 import com.microsoft.graph.requests.extensions.RoleDefinitionCollectionPage;
-import com.microsoft.graph.requests.extensions.RemoteAssistancePartnerCollectionResponse;
 import com.microsoft.graph.requests.extensions.RemoteAssistancePartnerCollectionPage;
-import com.microsoft.graph.requests.extensions.TelecomExpenseManagementPartnerCollectionResponse;
 import com.microsoft.graph.requests.extensions.TelecomExpenseManagementPartnerCollectionPage;
-import com.microsoft.graph.requests.extensions.DeviceManagementTroubleshootingEventCollectionResponse;
 import com.microsoft.graph.requests.extensions.DeviceManagementTroubleshootingEventCollectionPage;
-import com.microsoft.graph.requests.extensions.WindowsInformationProtectionAppLearningSummaryCollectionResponse;
 import com.microsoft.graph.requests.extensions.WindowsInformationProtectionAppLearningSummaryCollectionPage;
-import com.microsoft.graph.requests.extensions.WindowsInformationProtectionNetworkLearningSummaryCollectionResponse;
 import com.microsoft.graph.requests.extensions.WindowsInformationProtectionNetworkLearningSummaryCollectionPage;
 
 
@@ -395,355 +372,91 @@ public class DeviceManagement extends Entity implements IJsonBackedObject {
 
 
         if (json.has("termsAndConditions")) {
-            final TermsAndConditionsCollectionResponse response = new TermsAndConditionsCollectionResponse();
-            if (json.has("termsAndConditions@odata.nextLink")) {
-                response.nextLink = json.get("termsAndConditions@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("termsAndConditions").toString(), JsonObject[].class);
-            final TermsAndConditions[] array = new TermsAndConditions[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), TermsAndConditions.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            termsAndConditions = new TermsAndConditionsCollectionPage(response, null);
+            termsAndConditions = serializer.deserializeObject(json.get("termsAndConditions").toString(), TermsAndConditionsCollectionPage.class);
         }
 
         if (json.has("deviceCompliancePolicies")) {
-            final DeviceCompliancePolicyCollectionResponse response = new DeviceCompliancePolicyCollectionResponse();
-            if (json.has("deviceCompliancePolicies@odata.nextLink")) {
-                response.nextLink = json.get("deviceCompliancePolicies@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("deviceCompliancePolicies").toString(), JsonObject[].class);
-            final DeviceCompliancePolicy[] array = new DeviceCompliancePolicy[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DeviceCompliancePolicy.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            deviceCompliancePolicies = new DeviceCompliancePolicyCollectionPage(response, null);
+            deviceCompliancePolicies = serializer.deserializeObject(json.get("deviceCompliancePolicies").toString(), DeviceCompliancePolicyCollectionPage.class);
         }
 
         if (json.has("deviceCompliancePolicySettingStateSummaries")) {
-            final DeviceCompliancePolicySettingStateSummaryCollectionResponse response = new DeviceCompliancePolicySettingStateSummaryCollectionResponse();
-            if (json.has("deviceCompliancePolicySettingStateSummaries@odata.nextLink")) {
-                response.nextLink = json.get("deviceCompliancePolicySettingStateSummaries@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("deviceCompliancePolicySettingStateSummaries").toString(), JsonObject[].class);
-            final DeviceCompliancePolicySettingStateSummary[] array = new DeviceCompliancePolicySettingStateSummary[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DeviceCompliancePolicySettingStateSummary.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            deviceCompliancePolicySettingStateSummaries = new DeviceCompliancePolicySettingStateSummaryCollectionPage(response, null);
+            deviceCompliancePolicySettingStateSummaries = serializer.deserializeObject(json.get("deviceCompliancePolicySettingStateSummaries").toString(), DeviceCompliancePolicySettingStateSummaryCollectionPage.class);
         }
 
         if (json.has("deviceConfigurations")) {
-            final DeviceConfigurationCollectionResponse response = new DeviceConfigurationCollectionResponse();
-            if (json.has("deviceConfigurations@odata.nextLink")) {
-                response.nextLink = json.get("deviceConfigurations@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("deviceConfigurations").toString(), JsonObject[].class);
-            final DeviceConfiguration[] array = new DeviceConfiguration[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DeviceConfiguration.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            deviceConfigurations = new DeviceConfigurationCollectionPage(response, null);
+            deviceConfigurations = serializer.deserializeObject(json.get("deviceConfigurations").toString(), DeviceConfigurationCollectionPage.class);
         }
 
         if (json.has("iosUpdateStatuses")) {
-            final IosUpdateDeviceStatusCollectionResponse response = new IosUpdateDeviceStatusCollectionResponse();
-            if (json.has("iosUpdateStatuses@odata.nextLink")) {
-                response.nextLink = json.get("iosUpdateStatuses@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("iosUpdateStatuses").toString(), JsonObject[].class);
-            final IosUpdateDeviceStatus[] array = new IosUpdateDeviceStatus[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), IosUpdateDeviceStatus.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            iosUpdateStatuses = new IosUpdateDeviceStatusCollectionPage(response, null);
+            iosUpdateStatuses = serializer.deserializeObject(json.get("iosUpdateStatuses").toString(), IosUpdateDeviceStatusCollectionPage.class);
         }
 
         if (json.has("complianceManagementPartners")) {
-            final ComplianceManagementPartnerCollectionResponse response = new ComplianceManagementPartnerCollectionResponse();
-            if (json.has("complianceManagementPartners@odata.nextLink")) {
-                response.nextLink = json.get("complianceManagementPartners@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("complianceManagementPartners").toString(), JsonObject[].class);
-            final ComplianceManagementPartner[] array = new ComplianceManagementPartner[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), ComplianceManagementPartner.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            complianceManagementPartners = new ComplianceManagementPartnerCollectionPage(response, null);
+            complianceManagementPartners = serializer.deserializeObject(json.get("complianceManagementPartners").toString(), ComplianceManagementPartnerCollectionPage.class);
         }
 
         if (json.has("deviceCategories")) {
-            final DeviceCategoryCollectionResponse response = new DeviceCategoryCollectionResponse();
-            if (json.has("deviceCategories@odata.nextLink")) {
-                response.nextLink = json.get("deviceCategories@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("deviceCategories").toString(), JsonObject[].class);
-            final DeviceCategory[] array = new DeviceCategory[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DeviceCategory.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            deviceCategories = new DeviceCategoryCollectionPage(response, null);
+            deviceCategories = serializer.deserializeObject(json.get("deviceCategories").toString(), DeviceCategoryCollectionPage.class);
         }
 
         if (json.has("deviceEnrollmentConfigurations")) {
-            final DeviceEnrollmentConfigurationCollectionResponse response = new DeviceEnrollmentConfigurationCollectionResponse();
-            if (json.has("deviceEnrollmentConfigurations@odata.nextLink")) {
-                response.nextLink = json.get("deviceEnrollmentConfigurations@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("deviceEnrollmentConfigurations").toString(), JsonObject[].class);
-            final DeviceEnrollmentConfiguration[] array = new DeviceEnrollmentConfiguration[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DeviceEnrollmentConfiguration.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            deviceEnrollmentConfigurations = new DeviceEnrollmentConfigurationCollectionPage(response, null);
+            deviceEnrollmentConfigurations = serializer.deserializeObject(json.get("deviceEnrollmentConfigurations").toString(), DeviceEnrollmentConfigurationCollectionPage.class);
         }
 
         if (json.has("deviceManagementPartners")) {
-            final DeviceManagementPartnerCollectionResponse response = new DeviceManagementPartnerCollectionResponse();
-            if (json.has("deviceManagementPartners@odata.nextLink")) {
-                response.nextLink = json.get("deviceManagementPartners@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("deviceManagementPartners").toString(), JsonObject[].class);
-            final DeviceManagementPartner[] array = new DeviceManagementPartner[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DeviceManagementPartner.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            deviceManagementPartners = new DeviceManagementPartnerCollectionPage(response, null);
+            deviceManagementPartners = serializer.deserializeObject(json.get("deviceManagementPartners").toString(), DeviceManagementPartnerCollectionPage.class);
         }
 
         if (json.has("exchangeConnectors")) {
-            final DeviceManagementExchangeConnectorCollectionResponse response = new DeviceManagementExchangeConnectorCollectionResponse();
-            if (json.has("exchangeConnectors@odata.nextLink")) {
-                response.nextLink = json.get("exchangeConnectors@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("exchangeConnectors").toString(), JsonObject[].class);
-            final DeviceManagementExchangeConnector[] array = new DeviceManagementExchangeConnector[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DeviceManagementExchangeConnector.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            exchangeConnectors = new DeviceManagementExchangeConnectorCollectionPage(response, null);
+            exchangeConnectors = serializer.deserializeObject(json.get("exchangeConnectors").toString(), DeviceManagementExchangeConnectorCollectionPage.class);
         }
 
         if (json.has("mobileThreatDefenseConnectors")) {
-            final MobileThreatDefenseConnectorCollectionResponse response = new MobileThreatDefenseConnectorCollectionResponse();
-            if (json.has("mobileThreatDefenseConnectors@odata.nextLink")) {
-                response.nextLink = json.get("mobileThreatDefenseConnectors@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("mobileThreatDefenseConnectors").toString(), JsonObject[].class);
-            final MobileThreatDefenseConnector[] array = new MobileThreatDefenseConnector[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), MobileThreatDefenseConnector.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            mobileThreatDefenseConnectors = new MobileThreatDefenseConnectorCollectionPage(response, null);
+            mobileThreatDefenseConnectors = serializer.deserializeObject(json.get("mobileThreatDefenseConnectors").toString(), MobileThreatDefenseConnectorCollectionPage.class);
         }
 
         if (json.has("detectedApps")) {
-            final DetectedAppCollectionResponse response = new DetectedAppCollectionResponse();
-            if (json.has("detectedApps@odata.nextLink")) {
-                response.nextLink = json.get("detectedApps@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("detectedApps").toString(), JsonObject[].class);
-            final DetectedApp[] array = new DetectedApp[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DetectedApp.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            detectedApps = new DetectedAppCollectionPage(response, null);
+            detectedApps = serializer.deserializeObject(json.get("detectedApps").toString(), DetectedAppCollectionPage.class);
         }
 
         if (json.has("managedDevices")) {
-            final ManagedDeviceCollectionResponse response = new ManagedDeviceCollectionResponse();
-            if (json.has("managedDevices@odata.nextLink")) {
-                response.nextLink = json.get("managedDevices@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("managedDevices").toString(), JsonObject[].class);
-            final ManagedDevice[] array = new ManagedDevice[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), ManagedDevice.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            managedDevices = new ManagedDeviceCollectionPage(response, null);
+            managedDevices = serializer.deserializeObject(json.get("managedDevices").toString(), ManagedDeviceCollectionPage.class);
         }
 
         if (json.has("notificationMessageTemplates")) {
-            final NotificationMessageTemplateCollectionResponse response = new NotificationMessageTemplateCollectionResponse();
-            if (json.has("notificationMessageTemplates@odata.nextLink")) {
-                response.nextLink = json.get("notificationMessageTemplates@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("notificationMessageTemplates").toString(), JsonObject[].class);
-            final NotificationMessageTemplate[] array = new NotificationMessageTemplate[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), NotificationMessageTemplate.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            notificationMessageTemplates = new NotificationMessageTemplateCollectionPage(response, null);
+            notificationMessageTemplates = serializer.deserializeObject(json.get("notificationMessageTemplates").toString(), NotificationMessageTemplateCollectionPage.class);
         }
 
         if (json.has("resourceOperations")) {
-            final ResourceOperationCollectionResponse response = new ResourceOperationCollectionResponse();
-            if (json.has("resourceOperations@odata.nextLink")) {
-                response.nextLink = json.get("resourceOperations@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("resourceOperations").toString(), JsonObject[].class);
-            final ResourceOperation[] array = new ResourceOperation[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), ResourceOperation.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            resourceOperations = new ResourceOperationCollectionPage(response, null);
+            resourceOperations = serializer.deserializeObject(json.get("resourceOperations").toString(), ResourceOperationCollectionPage.class);
         }
 
         if (json.has("roleAssignments")) {
-            final DeviceAndAppManagementRoleAssignmentCollectionResponse response = new DeviceAndAppManagementRoleAssignmentCollectionResponse();
-            if (json.has("roleAssignments@odata.nextLink")) {
-                response.nextLink = json.get("roleAssignments@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("roleAssignments").toString(), JsonObject[].class);
-            final DeviceAndAppManagementRoleAssignment[] array = new DeviceAndAppManagementRoleAssignment[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DeviceAndAppManagementRoleAssignment.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            roleAssignments = new DeviceAndAppManagementRoleAssignmentCollectionPage(response, null);
+            roleAssignments = serializer.deserializeObject(json.get("roleAssignments").toString(), DeviceAndAppManagementRoleAssignmentCollectionPage.class);
         }
 
         if (json.has("roleDefinitions")) {
-            final RoleDefinitionCollectionResponse response = new RoleDefinitionCollectionResponse();
-            if (json.has("roleDefinitions@odata.nextLink")) {
-                response.nextLink = json.get("roleDefinitions@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("roleDefinitions").toString(), JsonObject[].class);
-            final RoleDefinition[] array = new RoleDefinition[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), RoleDefinition.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            roleDefinitions = new RoleDefinitionCollectionPage(response, null);
+            roleDefinitions = serializer.deserializeObject(json.get("roleDefinitions").toString(), RoleDefinitionCollectionPage.class);
         }
 
         if (json.has("remoteAssistancePartners")) {
-            final RemoteAssistancePartnerCollectionResponse response = new RemoteAssistancePartnerCollectionResponse();
-            if (json.has("remoteAssistancePartners@odata.nextLink")) {
-                response.nextLink = json.get("remoteAssistancePartners@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("remoteAssistancePartners").toString(), JsonObject[].class);
-            final RemoteAssistancePartner[] array = new RemoteAssistancePartner[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), RemoteAssistancePartner.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            remoteAssistancePartners = new RemoteAssistancePartnerCollectionPage(response, null);
+            remoteAssistancePartners = serializer.deserializeObject(json.get("remoteAssistancePartners").toString(), RemoteAssistancePartnerCollectionPage.class);
         }
 
         if (json.has("telecomExpenseManagementPartners")) {
-            final TelecomExpenseManagementPartnerCollectionResponse response = new TelecomExpenseManagementPartnerCollectionResponse();
-            if (json.has("telecomExpenseManagementPartners@odata.nextLink")) {
-                response.nextLink = json.get("telecomExpenseManagementPartners@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("telecomExpenseManagementPartners").toString(), JsonObject[].class);
-            final TelecomExpenseManagementPartner[] array = new TelecomExpenseManagementPartner[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), TelecomExpenseManagementPartner.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            telecomExpenseManagementPartners = new TelecomExpenseManagementPartnerCollectionPage(response, null);
+            telecomExpenseManagementPartners = serializer.deserializeObject(json.get("telecomExpenseManagementPartners").toString(), TelecomExpenseManagementPartnerCollectionPage.class);
         }
 
         if (json.has("troubleshootingEvents")) {
-            final DeviceManagementTroubleshootingEventCollectionResponse response = new DeviceManagementTroubleshootingEventCollectionResponse();
-            if (json.has("troubleshootingEvents@odata.nextLink")) {
-                response.nextLink = json.get("troubleshootingEvents@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("troubleshootingEvents").toString(), JsonObject[].class);
-            final DeviceManagementTroubleshootingEvent[] array = new DeviceManagementTroubleshootingEvent[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DeviceManagementTroubleshootingEvent.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            troubleshootingEvents = new DeviceManagementTroubleshootingEventCollectionPage(response, null);
+            troubleshootingEvents = serializer.deserializeObject(json.get("troubleshootingEvents").toString(), DeviceManagementTroubleshootingEventCollectionPage.class);
         }
 
         if (json.has("windowsInformationProtectionAppLearningSummaries")) {
-            final WindowsInformationProtectionAppLearningSummaryCollectionResponse response = new WindowsInformationProtectionAppLearningSummaryCollectionResponse();
-            if (json.has("windowsInformationProtectionAppLearningSummaries@odata.nextLink")) {
-                response.nextLink = json.get("windowsInformationProtectionAppLearningSummaries@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("windowsInformationProtectionAppLearningSummaries").toString(), JsonObject[].class);
-            final WindowsInformationProtectionAppLearningSummary[] array = new WindowsInformationProtectionAppLearningSummary[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), WindowsInformationProtectionAppLearningSummary.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            windowsInformationProtectionAppLearningSummaries = new WindowsInformationProtectionAppLearningSummaryCollectionPage(response, null);
+            windowsInformationProtectionAppLearningSummaries = serializer.deserializeObject(json.get("windowsInformationProtectionAppLearningSummaries").toString(), WindowsInformationProtectionAppLearningSummaryCollectionPage.class);
         }
 
         if (json.has("windowsInformationProtectionNetworkLearningSummaries")) {
-            final WindowsInformationProtectionNetworkLearningSummaryCollectionResponse response = new WindowsInformationProtectionNetworkLearningSummaryCollectionResponse();
-            if (json.has("windowsInformationProtectionNetworkLearningSummaries@odata.nextLink")) {
-                response.nextLink = json.get("windowsInformationProtectionNetworkLearningSummaries@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("windowsInformationProtectionNetworkLearningSummaries").toString(), JsonObject[].class);
-            final WindowsInformationProtectionNetworkLearningSummary[] array = new WindowsInformationProtectionNetworkLearningSummary[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), WindowsInformationProtectionNetworkLearningSummary.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            windowsInformationProtectionNetworkLearningSummaries = new WindowsInformationProtectionNetworkLearningSummaryCollectionPage(response, null);
+            windowsInformationProtectionNetworkLearningSummaries = serializer.deserializeObject(json.get("windowsInformationProtectionNetworkLearningSummaries").toString(), WindowsInformationProtectionNetworkLearningSummaryCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/DeviceManagementExchangeConnector.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DeviceManagementExchangeConnector.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.DeviceManagementExchangeConnectorType;
 import com.microsoft.graph.models.generated.DeviceManagementExchangeConnectorStatus;

--- a/src/main/java/com/microsoft/graph/models/extensions/DeviceManagementPartner.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DeviceManagementPartner.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.DeviceManagementPartnerAppType;
 import com.microsoft.graph.models.generated.DeviceManagementPartnerTenantState;

--- a/src/main/java/com/microsoft/graph/models/extensions/DeviceManagementSettings.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DeviceManagementSettings.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/DeviceManagementTroubleshootingEvent.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DeviceManagementTroubleshootingEvent.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Entity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/DeviceOperatingSystemSummary.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DeviceOperatingSystemSummary.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/Diagnostic.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Diagnostic.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/Directory.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Directory.java
@@ -6,14 +6,11 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.AdministrativeUnit;
 import com.microsoft.graph.models.extensions.DirectoryObject;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.AdministrativeUnitCollectionResponse;
 import com.microsoft.graph.requests.extensions.AdministrativeUnitCollectionPage;
-import com.microsoft.graph.requests.extensions.DirectoryObjectCollectionResponse;
 import com.microsoft.graph.requests.extensions.DirectoryObjectCollectionPage;
 
 
@@ -86,35 +83,11 @@ public class Directory extends Entity implements IJsonBackedObject {
 
 
         if (json.has("administrativeUnits")) {
-            final AdministrativeUnitCollectionResponse response = new AdministrativeUnitCollectionResponse();
-            if (json.has("administrativeUnits@odata.nextLink")) {
-                response.nextLink = json.get("administrativeUnits@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("administrativeUnits").toString(), JsonObject[].class);
-            final AdministrativeUnit[] array = new AdministrativeUnit[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), AdministrativeUnit.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            administrativeUnits = new AdministrativeUnitCollectionPage(response, null);
+            administrativeUnits = serializer.deserializeObject(json.get("administrativeUnits").toString(), AdministrativeUnitCollectionPage.class);
         }
 
         if (json.has("deletedItems")) {
-            final DirectoryObjectCollectionResponse response = new DirectoryObjectCollectionResponse();
-            if (json.has("deletedItems@odata.nextLink")) {
-                response.nextLink = json.get("deletedItems@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("deletedItems").toString(), JsonObject[].class);
-            final DirectoryObject[] array = new DirectoryObject[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DirectoryObject.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            deletedItems = new DirectoryObjectCollectionPage(response, null);
+            deletedItems = serializer.deserializeObject(json.get("deletedItems").toString(), DirectoryObjectCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/DirectoryAudit.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DirectoryAudit.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.KeyValue;
 import com.microsoft.graph.models.extensions.AuditActivityInitiator;

--- a/src/main/java/com/microsoft/graph/models/extensions/DirectoryObject.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DirectoryObject.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Entity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/DirectoryObjectPartnerReference.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DirectoryObjectPartnerReference.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.DirectoryObject;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/DirectoryRole.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DirectoryRole.java
@@ -6,13 +6,10 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.DirectoryObject;
 import com.microsoft.graph.models.extensions.ScopedRoleMembership;
-import com.microsoft.graph.requests.extensions.DirectoryObjectCollectionResponse;
 import com.microsoft.graph.requests.extensions.DirectoryObjectCollectionPage;
-import com.microsoft.graph.requests.extensions.ScopedRoleMembershipCollectionResponse;
 import com.microsoft.graph.requests.extensions.ScopedRoleMembershipCollectionPage;
 
 
@@ -107,35 +104,11 @@ public class DirectoryRole extends DirectoryObject implements IJsonBackedObject 
 
 
         if (json.has("members")) {
-            final DirectoryObjectCollectionResponse response = new DirectoryObjectCollectionResponse();
-            if (json.has("members@odata.nextLink")) {
-                response.nextLink = json.get("members@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("members").toString(), JsonObject[].class);
-            final DirectoryObject[] array = new DirectoryObject[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DirectoryObject.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            members = new DirectoryObjectCollectionPage(response, null);
+            members = serializer.deserializeObject(json.get("members").toString(), DirectoryObjectCollectionPage.class);
         }
 
         if (json.has("scopedMembers")) {
-            final ScopedRoleMembershipCollectionResponse response = new ScopedRoleMembershipCollectionResponse();
-            if (json.has("scopedMembers@odata.nextLink")) {
-                response.nextLink = json.get("scopedMembers@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("scopedMembers").toString(), JsonObject[].class);
-            final ScopedRoleMembership[] array = new ScopedRoleMembership[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), ScopedRoleMembership.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            scopedMembers = new ScopedRoleMembershipCollectionPage(response, null);
+            scopedMembers = serializer.deserializeObject(json.get("scopedMembers").toString(), ScopedRoleMembershipCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/DirectoryRoleTemplate.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DirectoryRoleTemplate.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.DirectoryObject;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/Domain.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Domain.java
@@ -6,15 +6,12 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.DomainState;
 import com.microsoft.graph.models.extensions.DirectoryObject;
 import com.microsoft.graph.models.extensions.DomainDnsRecord;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.DirectoryObjectCollectionResponse;
 import com.microsoft.graph.requests.extensions.DirectoryObjectCollectionPage;
-import com.microsoft.graph.requests.extensions.DomainDnsRecordCollectionResponse;
 import com.microsoft.graph.requests.extensions.DomainDnsRecordCollectionPage;
 
 
@@ -197,51 +194,15 @@ public class Domain extends Entity implements IJsonBackedObject {
 
 
         if (json.has("domainNameReferences")) {
-            final DirectoryObjectCollectionResponse response = new DirectoryObjectCollectionResponse();
-            if (json.has("domainNameReferences@odata.nextLink")) {
-                response.nextLink = json.get("domainNameReferences@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("domainNameReferences").toString(), JsonObject[].class);
-            final DirectoryObject[] array = new DirectoryObject[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DirectoryObject.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            domainNameReferences = new DirectoryObjectCollectionPage(response, null);
+            domainNameReferences = serializer.deserializeObject(json.get("domainNameReferences").toString(), DirectoryObjectCollectionPage.class);
         }
 
         if (json.has("serviceConfigurationRecords")) {
-            final DomainDnsRecordCollectionResponse response = new DomainDnsRecordCollectionResponse();
-            if (json.has("serviceConfigurationRecords@odata.nextLink")) {
-                response.nextLink = json.get("serviceConfigurationRecords@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("serviceConfigurationRecords").toString(), JsonObject[].class);
-            final DomainDnsRecord[] array = new DomainDnsRecord[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DomainDnsRecord.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            serviceConfigurationRecords = new DomainDnsRecordCollectionPage(response, null);
+            serviceConfigurationRecords = serializer.deserializeObject(json.get("serviceConfigurationRecords").toString(), DomainDnsRecordCollectionPage.class);
         }
 
         if (json.has("verificationDnsRecords")) {
-            final DomainDnsRecordCollectionResponse response = new DomainDnsRecordCollectionResponse();
-            if (json.has("verificationDnsRecords@odata.nextLink")) {
-                response.nextLink = json.get("verificationDnsRecords@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("verificationDnsRecords").toString(), JsonObject[].class);
-            final DomainDnsRecord[] array = new DomainDnsRecord[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DomainDnsRecord.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            verificationDnsRecords = new DomainDnsRecordCollectionPage(response, null);
+            verificationDnsRecords = serializer.deserializeObject(json.get("verificationDnsRecords").toString(), DomainDnsRecordCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/DomainDnsCnameRecord.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DomainDnsCnameRecord.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.DomainDnsRecord;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/DomainDnsMxRecord.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DomainDnsMxRecord.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.DomainDnsRecord;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/DomainDnsRecord.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DomainDnsRecord.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Entity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/DomainDnsSrvRecord.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DomainDnsSrvRecord.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.DomainDnsRecord;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/DomainDnsTxtRecord.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DomainDnsTxtRecord.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.DomainDnsRecord;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/DomainDnsUnavailableRecord.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DomainDnsUnavailableRecord.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.DomainDnsRecord;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/DomainState.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DomainState.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/Drive.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Drive.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.IdentitySet;
 import com.microsoft.graph.models.extensions.Quota;
@@ -15,7 +14,6 @@ import com.microsoft.graph.models.extensions.SystemFacet;
 import com.microsoft.graph.models.extensions.DriveItem;
 import com.microsoft.graph.models.extensions.List;
 import com.microsoft.graph.models.extensions.BaseItem;
-import com.microsoft.graph.requests.extensions.DriveItemCollectionResponse;
 import com.microsoft.graph.requests.extensions.DriveItemCollectionPage;
 
 
@@ -152,51 +150,15 @@ public class Drive extends BaseItem implements IJsonBackedObject {
 
 
         if (json.has("following")) {
-            final DriveItemCollectionResponse response = new DriveItemCollectionResponse();
-            if (json.has("following@odata.nextLink")) {
-                response.nextLink = json.get("following@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("following").toString(), JsonObject[].class);
-            final DriveItem[] array = new DriveItem[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DriveItem.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            following = new DriveItemCollectionPage(response, null);
+            following = serializer.deserializeObject(json.get("following").toString(), DriveItemCollectionPage.class);
         }
 
         if (json.has("items")) {
-            final DriveItemCollectionResponse response = new DriveItemCollectionResponse();
-            if (json.has("items@odata.nextLink")) {
-                response.nextLink = json.get("items@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("items").toString(), JsonObject[].class);
-            final DriveItem[] array = new DriveItem[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DriveItem.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            items = new DriveItemCollectionPage(response, null);
+            items = serializer.deserializeObject(json.get("items").toString(), DriveItemCollectionPage.class);
         }
 
         if (json.has("special")) {
-            final DriveItemCollectionResponse response = new DriveItemCollectionResponse();
-            if (json.has("special@odata.nextLink")) {
-                response.nextLink = json.get("special@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("special").toString(), JsonObject[].class);
-            final DriveItem[] array = new DriveItem[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DriveItem.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            special = new DriveItemCollectionPage(response, null);
+            special = serializer.deserializeObject(json.get("special").toString(), DriveItemCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/DriveItem.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DriveItem.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Audio;
 import com.microsoft.graph.models.extensions.Deleted;
@@ -34,15 +33,10 @@ import com.microsoft.graph.models.extensions.Subscription;
 import com.microsoft.graph.models.extensions.ThumbnailSet;
 import com.microsoft.graph.models.extensions.DriveItemVersion;
 import com.microsoft.graph.models.extensions.BaseItem;
-import com.microsoft.graph.requests.extensions.DriveItemCollectionResponse;
 import com.microsoft.graph.requests.extensions.DriveItemCollectionPage;
-import com.microsoft.graph.requests.extensions.PermissionCollectionResponse;
 import com.microsoft.graph.requests.extensions.PermissionCollectionPage;
-import com.microsoft.graph.requests.extensions.SubscriptionCollectionResponse;
 import com.microsoft.graph.requests.extensions.SubscriptionCollectionPage;
-import com.microsoft.graph.requests.extensions.ThumbnailSetCollectionResponse;
 import com.microsoft.graph.requests.extensions.ThumbnailSetCollectionPage;
-import com.microsoft.graph.requests.extensions.DriveItemVersionCollectionResponse;
 import com.microsoft.graph.requests.extensions.DriveItemVersionCollectionPage;
 
 
@@ -331,83 +325,23 @@ public class DriveItem extends BaseItem implements IJsonBackedObject {
 
 
         if (json.has("children")) {
-            final DriveItemCollectionResponse response = new DriveItemCollectionResponse();
-            if (json.has("children@odata.nextLink")) {
-                response.nextLink = json.get("children@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("children").toString(), JsonObject[].class);
-            final DriveItem[] array = new DriveItem[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DriveItem.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            children = new DriveItemCollectionPage(response, null);
+            children = serializer.deserializeObject(json.get("children").toString(), DriveItemCollectionPage.class);
         }
 
         if (json.has("permissions")) {
-            final PermissionCollectionResponse response = new PermissionCollectionResponse();
-            if (json.has("permissions@odata.nextLink")) {
-                response.nextLink = json.get("permissions@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("permissions").toString(), JsonObject[].class);
-            final Permission[] array = new Permission[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), Permission.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            permissions = new PermissionCollectionPage(response, null);
+            permissions = serializer.deserializeObject(json.get("permissions").toString(), PermissionCollectionPage.class);
         }
 
         if (json.has("subscriptions")) {
-            final SubscriptionCollectionResponse response = new SubscriptionCollectionResponse();
-            if (json.has("subscriptions@odata.nextLink")) {
-                response.nextLink = json.get("subscriptions@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("subscriptions").toString(), JsonObject[].class);
-            final Subscription[] array = new Subscription[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), Subscription.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            subscriptions = new SubscriptionCollectionPage(response, null);
+            subscriptions = serializer.deserializeObject(json.get("subscriptions").toString(), SubscriptionCollectionPage.class);
         }
 
         if (json.has("thumbnails")) {
-            final ThumbnailSetCollectionResponse response = new ThumbnailSetCollectionResponse();
-            if (json.has("thumbnails@odata.nextLink")) {
-                response.nextLink = json.get("thumbnails@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("thumbnails").toString(), JsonObject[].class);
-            final ThumbnailSet[] array = new ThumbnailSet[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), ThumbnailSet.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            thumbnails = new ThumbnailSetCollectionPage(response, null);
+            thumbnails = serializer.deserializeObject(json.get("thumbnails").toString(), ThumbnailSetCollectionPage.class);
         }
 
         if (json.has("versions")) {
-            final DriveItemVersionCollectionResponse response = new DriveItemVersionCollectionResponse();
-            if (json.has("versions@odata.nextLink")) {
-                response.nextLink = json.get("versions@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("versions").toString(), JsonObject[].class);
-            final DriveItemVersion[] array = new DriveItemVersion[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DriveItemVersion.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            versions = new DriveItemVersionCollectionPage(response, null);
+            versions = serializer.deserializeObject(json.get("versions").toString(), DriveItemVersionCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/DriveItemUploadableProperties.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DriveItemUploadableProperties.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.FileSystemInfo;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/DriveItemVersion.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DriveItemVersion.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.BaseItemVersion;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/DriveRecipient.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/DriveRecipient.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/EBookInstallSummary.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/EBookInstallSummary.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Entity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/EdgeSearchEngine.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/EdgeSearchEngine.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.EdgeSearchEngineType;
 import com.microsoft.graph.models.extensions.EdgeSearchEngineBase;

--- a/src/main/java/com/microsoft/graph/models/extensions/EdgeSearchEngineBase.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/EdgeSearchEngineBase.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/EdgeSearchEngineCustom.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/EdgeSearchEngineCustom.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.EdgeSearchEngineBase;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/EditionUpgradeConfiguration.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/EditionUpgradeConfiguration.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.EditionUpgradeLicenseType;
 import com.microsoft.graph.models.generated.Windows10EditionType;

--- a/src/main/java/com/microsoft/graph/models/extensions/EducationClass.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/EducationClass.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.IdentitySet;
 import com.microsoft.graph.models.generated.EducationExternalSource;
@@ -15,9 +14,7 @@ import com.microsoft.graph.models.extensions.Group;
 import com.microsoft.graph.models.extensions.EducationUser;
 import com.microsoft.graph.models.extensions.EducationSchool;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.EducationUserCollectionResponse;
 import com.microsoft.graph.requests.extensions.EducationUserCollectionPage;
-import com.microsoft.graph.requests.extensions.EducationSchoolCollectionResponse;
 import com.microsoft.graph.requests.extensions.EducationSchoolCollectionPage;
 
 
@@ -172,51 +169,15 @@ public class EducationClass extends Entity implements IJsonBackedObject {
 
 
         if (json.has("members")) {
-            final EducationUserCollectionResponse response = new EducationUserCollectionResponse();
-            if (json.has("members@odata.nextLink")) {
-                response.nextLink = json.get("members@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("members").toString(), JsonObject[].class);
-            final EducationUser[] array = new EducationUser[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), EducationUser.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            members = new EducationUserCollectionPage(response, null);
+            members = serializer.deserializeObject(json.get("members").toString(), EducationUserCollectionPage.class);
         }
 
         if (json.has("schools")) {
-            final EducationSchoolCollectionResponse response = new EducationSchoolCollectionResponse();
-            if (json.has("schools@odata.nextLink")) {
-                response.nextLink = json.get("schools@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("schools").toString(), JsonObject[].class);
-            final EducationSchool[] array = new EducationSchool[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), EducationSchool.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            schools = new EducationSchoolCollectionPage(response, null);
+            schools = serializer.deserializeObject(json.get("schools").toString(), EducationSchoolCollectionPage.class);
         }
 
         if (json.has("teachers")) {
-            final EducationUserCollectionResponse response = new EducationUserCollectionResponse();
-            if (json.has("teachers@odata.nextLink")) {
-                response.nextLink = json.get("teachers@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("teachers").toString(), JsonObject[].class);
-            final EducationUser[] array = new EducationUser[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), EducationUser.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            teachers = new EducationUserCollectionPage(response, null);
+            teachers = serializer.deserializeObject(json.get("teachers").toString(), EducationUserCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/EducationOrganization.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/EducationOrganization.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.EducationExternalSource;
 import com.microsoft.graph.models.extensions.Entity;

--- a/src/main/java/com/microsoft/graph/models/extensions/EducationRoot.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/EducationRoot.java
@@ -6,17 +6,13 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.EducationClass;
 import com.microsoft.graph.models.extensions.EducationUser;
 import com.microsoft.graph.models.extensions.EducationSchool;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.EducationClassCollectionResponse;
 import com.microsoft.graph.requests.extensions.EducationClassCollectionPage;
-import com.microsoft.graph.requests.extensions.EducationSchoolCollectionResponse;
 import com.microsoft.graph.requests.extensions.EducationSchoolCollectionPage;
-import com.microsoft.graph.requests.extensions.EducationUserCollectionResponse;
 import com.microsoft.graph.requests.extensions.EducationUserCollectionPage;
 
 
@@ -105,51 +101,15 @@ public class EducationRoot extends Entity implements IJsonBackedObject {
 
 
         if (json.has("classes")) {
-            final EducationClassCollectionResponse response = new EducationClassCollectionResponse();
-            if (json.has("classes@odata.nextLink")) {
-                response.nextLink = json.get("classes@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("classes").toString(), JsonObject[].class);
-            final EducationClass[] array = new EducationClass[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), EducationClass.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            classes = new EducationClassCollectionPage(response, null);
+            classes = serializer.deserializeObject(json.get("classes").toString(), EducationClassCollectionPage.class);
         }
 
         if (json.has("schools")) {
-            final EducationSchoolCollectionResponse response = new EducationSchoolCollectionResponse();
-            if (json.has("schools@odata.nextLink")) {
-                response.nextLink = json.get("schools@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("schools").toString(), JsonObject[].class);
-            final EducationSchool[] array = new EducationSchool[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), EducationSchool.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            schools = new EducationSchoolCollectionPage(response, null);
+            schools = serializer.deserializeObject(json.get("schools").toString(), EducationSchoolCollectionPage.class);
         }
 
         if (json.has("users")) {
-            final EducationUserCollectionResponse response = new EducationUserCollectionResponse();
-            if (json.has("users@odata.nextLink")) {
-                response.nextLink = json.get("users@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("users").toString(), JsonObject[].class);
-            final EducationUser[] array = new EducationUser[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), EducationUser.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            users = new EducationUserCollectionPage(response, null);
+            users = serializer.deserializeObject(json.get("users").toString(), EducationUserCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/EducationSchool.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/EducationSchool.java
@@ -6,16 +6,13 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.PhysicalAddress;
 import com.microsoft.graph.models.extensions.IdentitySet;
 import com.microsoft.graph.models.extensions.EducationClass;
 import com.microsoft.graph.models.extensions.EducationUser;
 import com.microsoft.graph.models.extensions.EducationOrganization;
-import com.microsoft.graph.requests.extensions.EducationClassCollectionResponse;
 import com.microsoft.graph.requests.extensions.EducationClassCollectionPage;
-import com.microsoft.graph.requests.extensions.EducationUserCollectionResponse;
 import com.microsoft.graph.requests.extensions.EducationUserCollectionPage;
 
 
@@ -172,35 +169,11 @@ public class EducationSchool extends EducationOrganization implements IJsonBacke
 
 
         if (json.has("classes")) {
-            final EducationClassCollectionResponse response = new EducationClassCollectionResponse();
-            if (json.has("classes@odata.nextLink")) {
-                response.nextLink = json.get("classes@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("classes").toString(), JsonObject[].class);
-            final EducationClass[] array = new EducationClass[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), EducationClass.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            classes = new EducationClassCollectionPage(response, null);
+            classes = serializer.deserializeObject(json.get("classes").toString(), EducationClassCollectionPage.class);
         }
 
         if (json.has("users")) {
-            final EducationUserCollectionResponse response = new EducationUserCollectionResponse();
-            if (json.has("users@odata.nextLink")) {
-                response.nextLink = json.get("users@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("users").toString(), JsonObject[].class);
-            final EducationUser[] array = new EducationUser[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), EducationUser.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            users = new EducationUserCollectionPage(response, null);
+            users = serializer.deserializeObject(json.get("users").toString(), EducationUserCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/EducationStudent.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/EducationStudent.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.EducationGender;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/EducationTeacher.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/EducationTeacher.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/EducationTerm.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/EducationTerm.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/EducationUser.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/EducationUser.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.AssignedLicense;
 import com.microsoft.graph.models.extensions.AssignedPlan;
@@ -22,9 +21,7 @@ import com.microsoft.graph.models.extensions.EducationClass;
 import com.microsoft.graph.models.extensions.EducationSchool;
 import com.microsoft.graph.models.extensions.User;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.EducationClassCollectionResponse;
 import com.microsoft.graph.requests.extensions.EducationClassCollectionPage;
-import com.microsoft.graph.requests.extensions.EducationSchoolCollectionResponse;
 import com.microsoft.graph.requests.extensions.EducationSchoolCollectionPage;
 
 
@@ -333,35 +330,11 @@ public class EducationUser extends Entity implements IJsonBackedObject {
 
 
         if (json.has("classes")) {
-            final EducationClassCollectionResponse response = new EducationClassCollectionResponse();
-            if (json.has("classes@odata.nextLink")) {
-                response.nextLink = json.get("classes@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("classes").toString(), JsonObject[].class);
-            final EducationClass[] array = new EducationClass[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), EducationClass.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            classes = new EducationClassCollectionPage(response, null);
+            classes = serializer.deserializeObject(json.get("classes").toString(), EducationClassCollectionPage.class);
         }
 
         if (json.has("schools")) {
-            final EducationSchoolCollectionResponse response = new EducationSchoolCollectionResponse();
-            if (json.has("schools@odata.nextLink")) {
-                response.nextLink = json.get("schools@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("schools").toString(), JsonObject[].class);
-            final EducationSchool[] array = new EducationSchool[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), EducationSchool.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            schools = new EducationSchoolCollectionPage(response, null);
+            schools = serializer.deserializeObject(json.get("schools").toString(), EducationSchoolCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/EmailAddress.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/EmailAddress.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/EmailFileAssessmentRequest.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/EmailFileAssessmentRequest.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.MailDestinationRoutingReason;
 import com.microsoft.graph.models.extensions.ThreatAssessmentRequest;

--- a/src/main/java/com/microsoft/graph/models/extensions/Endpoint.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Endpoint.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.DirectoryObject;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/EnrollmentConfigurationAssignment.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/EnrollmentConfigurationAssignment.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.DeviceAndAppManagementAssignmentTarget;
 import com.microsoft.graph.models.extensions.Entity;

--- a/src/main/java/com/microsoft/graph/models/extensions/EnrollmentTroubleshootingEvent.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/EnrollmentTroubleshootingEvent.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.DeviceEnrollmentType;
 import com.microsoft.graph.models.generated.DeviceEnrollmentFailureReason;

--- a/src/main/java/com/microsoft/graph/models/extensions/Entity.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Entity.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/Event.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Event.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Attendee;
 import com.microsoft.graph.models.extensions.ItemBody;
@@ -28,15 +27,10 @@ import com.microsoft.graph.models.extensions.Event;
 import com.microsoft.graph.models.extensions.MultiValueLegacyExtendedProperty;
 import com.microsoft.graph.models.extensions.SingleValueLegacyExtendedProperty;
 import com.microsoft.graph.models.extensions.OutlookItem;
-import com.microsoft.graph.requests.extensions.AttachmentCollectionResponse;
 import com.microsoft.graph.requests.extensions.AttachmentCollectionPage;
-import com.microsoft.graph.requests.extensions.ExtensionCollectionResponse;
 import com.microsoft.graph.requests.extensions.ExtensionCollectionPage;
-import com.microsoft.graph.requests.extensions.EventCollectionResponse;
 import com.microsoft.graph.requests.extensions.EventCollectionPage;
-import com.microsoft.graph.requests.extensions.MultiValueLegacyExtendedPropertyCollectionResponse;
 import com.microsoft.graph.requests.extensions.MultiValueLegacyExtendedPropertyCollectionPage;
-import com.microsoft.graph.requests.extensions.SingleValueLegacyExtendedPropertyCollectionResponse;
 import com.microsoft.graph.requests.extensions.SingleValueLegacyExtendedPropertyCollectionPage;
 
 
@@ -413,83 +407,23 @@ public class Event extends OutlookItem implements IJsonBackedObject {
 
 
         if (json.has("attachments")) {
-            final AttachmentCollectionResponse response = new AttachmentCollectionResponse();
-            if (json.has("attachments@odata.nextLink")) {
-                response.nextLink = json.get("attachments@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("attachments").toString(), JsonObject[].class);
-            final Attachment[] array = new Attachment[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), Attachment.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            attachments = new AttachmentCollectionPage(response, null);
+            attachments = serializer.deserializeObject(json.get("attachments").toString(), AttachmentCollectionPage.class);
         }
 
         if (json.has("extensions")) {
-            final ExtensionCollectionResponse response = new ExtensionCollectionResponse();
-            if (json.has("extensions@odata.nextLink")) {
-                response.nextLink = json.get("extensions@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("extensions").toString(), JsonObject[].class);
-            final Extension[] array = new Extension[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), Extension.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            extensions = new ExtensionCollectionPage(response, null);
+            extensions = serializer.deserializeObject(json.get("extensions").toString(), ExtensionCollectionPage.class);
         }
 
         if (json.has("instances")) {
-            final EventCollectionResponse response = new EventCollectionResponse();
-            if (json.has("instances@odata.nextLink")) {
-                response.nextLink = json.get("instances@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("instances").toString(), JsonObject[].class);
-            final Event[] array = new Event[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), Event.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            instances = new EventCollectionPage(response, null);
+            instances = serializer.deserializeObject(json.get("instances").toString(), EventCollectionPage.class);
         }
 
         if (json.has("multiValueExtendedProperties")) {
-            final MultiValueLegacyExtendedPropertyCollectionResponse response = new MultiValueLegacyExtendedPropertyCollectionResponse();
-            if (json.has("multiValueExtendedProperties@odata.nextLink")) {
-                response.nextLink = json.get("multiValueExtendedProperties@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("multiValueExtendedProperties").toString(), JsonObject[].class);
-            final MultiValueLegacyExtendedProperty[] array = new MultiValueLegacyExtendedProperty[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), MultiValueLegacyExtendedProperty.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            multiValueExtendedProperties = new MultiValueLegacyExtendedPropertyCollectionPage(response, null);
+            multiValueExtendedProperties = serializer.deserializeObject(json.get("multiValueExtendedProperties").toString(), MultiValueLegacyExtendedPropertyCollectionPage.class);
         }
 
         if (json.has("singleValueExtendedProperties")) {
-            final SingleValueLegacyExtendedPropertyCollectionResponse response = new SingleValueLegacyExtendedPropertyCollectionResponse();
-            if (json.has("singleValueExtendedProperties@odata.nextLink")) {
-                response.nextLink = json.get("singleValueExtendedProperties@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("singleValueExtendedProperties").toString(), JsonObject[].class);
-            final SingleValueLegacyExtendedProperty[] array = new SingleValueLegacyExtendedProperty[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), SingleValueLegacyExtendedProperty.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            singleValueExtendedProperties = new SingleValueLegacyExtendedPropertyCollectionPage(response, null);
+            singleValueExtendedProperties = serializer.deserializeObject(json.get("singleValueExtendedProperties").toString(), SingleValueLegacyExtendedPropertyCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/EventMessage.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/EventMessage.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.DateTimeTimeZone;
 import com.microsoft.graph.models.extensions.Location;

--- a/src/main/java/com/microsoft/graph/models/extensions/EventMessageRequest.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/EventMessageRequest.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.MeetingRequestType;
 import com.microsoft.graph.models.extensions.DateTimeTimeZone;

--- a/src/main/java/com/microsoft/graph/models/extensions/EventMessageResponse.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/EventMessageResponse.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.TimeSlot;
 import com.microsoft.graph.models.generated.ResponseType;

--- a/src/main/java/com/microsoft/graph/models/extensions/ExclusionGroupAssignmentTarget.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ExclusionGroupAssignmentTarget.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.GroupAssignmentTarget;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/Extension.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Extension.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Entity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ExtensionProperty.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ExtensionProperty.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.DirectoryObject;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ExtensionSchemaProperty.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ExtensionSchemaProperty.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ExternalLink.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ExternalLink.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/FieldValueSet.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/FieldValueSet.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Entity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/File.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/File.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Hashes;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/FileAssessmentRequest.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/FileAssessmentRequest.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.ThreatAssessmentRequest;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/FileAttachment.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/FileAttachment.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Attachment;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/FileEncryptionInfo.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/FileEncryptionInfo.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/FileHash.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/FileHash.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.FileHashType;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/FileSecurityState.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/FileSecurityState.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.FileHash;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/FileSystemInfo.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/FileSystemInfo.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/Folder.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Folder.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.FolderView;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/FolderView.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/FolderView.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/FollowupFlag.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/FollowupFlag.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.DateTimeTimeZone;
 import com.microsoft.graph.models.generated.FollowupFlagStatus;

--- a/src/main/java/com/microsoft/graph/models/extensions/FreeBusyError.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/FreeBusyError.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/GenericError.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/GenericError.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/GeoCoordinates.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/GeoCoordinates.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/GeolocationColumn.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/GeolocationColumn.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/Group.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Group.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.AssignedLabel;
 import com.microsoft.graph.models.extensions.AssignedLicense;
@@ -27,27 +26,16 @@ import com.microsoft.graph.models.extensions.GroupLifecyclePolicy;
 import com.microsoft.graph.models.extensions.PlannerGroup;
 import com.microsoft.graph.models.extensions.Onenote;
 import com.microsoft.graph.models.extensions.Team;
-import com.microsoft.graph.requests.extensions.AppRoleAssignmentCollectionResponse;
 import com.microsoft.graph.requests.extensions.AppRoleAssignmentCollectionPage;
-import com.microsoft.graph.requests.extensions.DirectoryObjectCollectionResponse;
 import com.microsoft.graph.requests.extensions.DirectoryObjectCollectionPage;
-import com.microsoft.graph.requests.extensions.GroupSettingCollectionResponse;
 import com.microsoft.graph.requests.extensions.GroupSettingCollectionPage;
-import com.microsoft.graph.requests.extensions.EventCollectionResponse;
 import com.microsoft.graph.requests.extensions.EventCollectionPage;
-import com.microsoft.graph.requests.extensions.ConversationCollectionResponse;
 import com.microsoft.graph.requests.extensions.ConversationCollectionPage;
-import com.microsoft.graph.requests.extensions.ProfilePhotoCollectionResponse;
 import com.microsoft.graph.requests.extensions.ProfilePhotoCollectionPage;
-import com.microsoft.graph.requests.extensions.ConversationThreadCollectionResponse;
 import com.microsoft.graph.requests.extensions.ConversationThreadCollectionPage;
-import com.microsoft.graph.requests.extensions.DriveCollectionResponse;
 import com.microsoft.graph.requests.extensions.DriveCollectionPage;
-import com.microsoft.graph.requests.extensions.SiteCollectionResponse;
 import com.microsoft.graph.requests.extensions.SiteCollectionPage;
-import com.microsoft.graph.requests.extensions.ExtensionCollectionResponse;
 import com.microsoft.graph.requests.extensions.ExtensionCollectionPage;
-import com.microsoft.graph.requests.extensions.GroupLifecyclePolicyCollectionResponse;
 import com.microsoft.graph.requests.extensions.GroupLifecyclePolicyCollectionPage;
 
 
@@ -596,307 +584,79 @@ public class Group extends DirectoryObject implements IJsonBackedObject {
 
 
         if (json.has("appRoleAssignments")) {
-            final AppRoleAssignmentCollectionResponse response = new AppRoleAssignmentCollectionResponse();
-            if (json.has("appRoleAssignments@odata.nextLink")) {
-                response.nextLink = json.get("appRoleAssignments@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("appRoleAssignments").toString(), JsonObject[].class);
-            final AppRoleAssignment[] array = new AppRoleAssignment[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), AppRoleAssignment.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            appRoleAssignments = new AppRoleAssignmentCollectionPage(response, null);
+            appRoleAssignments = serializer.deserializeObject(json.get("appRoleAssignments").toString(), AppRoleAssignmentCollectionPage.class);
         }
 
         if (json.has("memberOf")) {
-            final DirectoryObjectCollectionResponse response = new DirectoryObjectCollectionResponse();
-            if (json.has("memberOf@odata.nextLink")) {
-                response.nextLink = json.get("memberOf@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("memberOf").toString(), JsonObject[].class);
-            final DirectoryObject[] array = new DirectoryObject[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DirectoryObject.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            memberOf = new DirectoryObjectCollectionPage(response, null);
+            memberOf = serializer.deserializeObject(json.get("memberOf").toString(), DirectoryObjectCollectionPage.class);
         }
 
         if (json.has("members")) {
-            final DirectoryObjectCollectionResponse response = new DirectoryObjectCollectionResponse();
-            if (json.has("members@odata.nextLink")) {
-                response.nextLink = json.get("members@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("members").toString(), JsonObject[].class);
-            final DirectoryObject[] array = new DirectoryObject[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DirectoryObject.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            members = new DirectoryObjectCollectionPage(response, null);
+            members = serializer.deserializeObject(json.get("members").toString(), DirectoryObjectCollectionPage.class);
         }
 
         if (json.has("membersWithLicenseErrors")) {
-            final DirectoryObjectCollectionResponse response = new DirectoryObjectCollectionResponse();
-            if (json.has("membersWithLicenseErrors@odata.nextLink")) {
-                response.nextLink = json.get("membersWithLicenseErrors@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("membersWithLicenseErrors").toString(), JsonObject[].class);
-            final DirectoryObject[] array = new DirectoryObject[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DirectoryObject.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            membersWithLicenseErrors = new DirectoryObjectCollectionPage(response, null);
+            membersWithLicenseErrors = serializer.deserializeObject(json.get("membersWithLicenseErrors").toString(), DirectoryObjectCollectionPage.class);
         }
 
         if (json.has("owners")) {
-            final DirectoryObjectCollectionResponse response = new DirectoryObjectCollectionResponse();
-            if (json.has("owners@odata.nextLink")) {
-                response.nextLink = json.get("owners@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("owners").toString(), JsonObject[].class);
-            final DirectoryObject[] array = new DirectoryObject[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DirectoryObject.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            owners = new DirectoryObjectCollectionPage(response, null);
+            owners = serializer.deserializeObject(json.get("owners").toString(), DirectoryObjectCollectionPage.class);
         }
 
         if (json.has("settings")) {
-            final GroupSettingCollectionResponse response = new GroupSettingCollectionResponse();
-            if (json.has("settings@odata.nextLink")) {
-                response.nextLink = json.get("settings@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("settings").toString(), JsonObject[].class);
-            final GroupSetting[] array = new GroupSetting[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), GroupSetting.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            settings = new GroupSettingCollectionPage(response, null);
+            settings = serializer.deserializeObject(json.get("settings").toString(), GroupSettingCollectionPage.class);
         }
 
         if (json.has("transitiveMemberOf")) {
-            final DirectoryObjectCollectionResponse response = new DirectoryObjectCollectionResponse();
-            if (json.has("transitiveMemberOf@odata.nextLink")) {
-                response.nextLink = json.get("transitiveMemberOf@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("transitiveMemberOf").toString(), JsonObject[].class);
-            final DirectoryObject[] array = new DirectoryObject[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DirectoryObject.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            transitiveMemberOf = new DirectoryObjectCollectionPage(response, null);
+            transitiveMemberOf = serializer.deserializeObject(json.get("transitiveMemberOf").toString(), DirectoryObjectCollectionPage.class);
         }
 
         if (json.has("transitiveMembers")) {
-            final DirectoryObjectCollectionResponse response = new DirectoryObjectCollectionResponse();
-            if (json.has("transitiveMembers@odata.nextLink")) {
-                response.nextLink = json.get("transitiveMembers@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("transitiveMembers").toString(), JsonObject[].class);
-            final DirectoryObject[] array = new DirectoryObject[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DirectoryObject.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            transitiveMembers = new DirectoryObjectCollectionPage(response, null);
+            transitiveMembers = serializer.deserializeObject(json.get("transitiveMembers").toString(), DirectoryObjectCollectionPage.class);
         }
 
         if (json.has("acceptedSenders")) {
-            final DirectoryObjectCollectionResponse response = new DirectoryObjectCollectionResponse();
-            if (json.has("acceptedSenders@odata.nextLink")) {
-                response.nextLink = json.get("acceptedSenders@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("acceptedSenders").toString(), JsonObject[].class);
-            final DirectoryObject[] array = new DirectoryObject[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DirectoryObject.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            acceptedSenders = new DirectoryObjectCollectionPage(response, null);
+            acceptedSenders = serializer.deserializeObject(json.get("acceptedSenders").toString(), DirectoryObjectCollectionPage.class);
         }
 
         if (json.has("calendarView")) {
-            final EventCollectionResponse response = new EventCollectionResponse();
-            if (json.has("calendarView@odata.nextLink")) {
-                response.nextLink = json.get("calendarView@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("calendarView").toString(), JsonObject[].class);
-            final Event[] array = new Event[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), Event.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            calendarView = new EventCollectionPage(response, null);
+            calendarView = serializer.deserializeObject(json.get("calendarView").toString(), EventCollectionPage.class);
         }
 
         if (json.has("conversations")) {
-            final ConversationCollectionResponse response = new ConversationCollectionResponse();
-            if (json.has("conversations@odata.nextLink")) {
-                response.nextLink = json.get("conversations@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("conversations").toString(), JsonObject[].class);
-            final Conversation[] array = new Conversation[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), Conversation.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            conversations = new ConversationCollectionPage(response, null);
+            conversations = serializer.deserializeObject(json.get("conversations").toString(), ConversationCollectionPage.class);
         }
 
         if (json.has("events")) {
-            final EventCollectionResponse response = new EventCollectionResponse();
-            if (json.has("events@odata.nextLink")) {
-                response.nextLink = json.get("events@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("events").toString(), JsonObject[].class);
-            final Event[] array = new Event[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), Event.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            events = new EventCollectionPage(response, null);
+            events = serializer.deserializeObject(json.get("events").toString(), EventCollectionPage.class);
         }
 
         if (json.has("photos")) {
-            final ProfilePhotoCollectionResponse response = new ProfilePhotoCollectionResponse();
-            if (json.has("photos@odata.nextLink")) {
-                response.nextLink = json.get("photos@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("photos").toString(), JsonObject[].class);
-            final ProfilePhoto[] array = new ProfilePhoto[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), ProfilePhoto.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            photos = new ProfilePhotoCollectionPage(response, null);
+            photos = serializer.deserializeObject(json.get("photos").toString(), ProfilePhotoCollectionPage.class);
         }
 
         if (json.has("rejectedSenders")) {
-            final DirectoryObjectCollectionResponse response = new DirectoryObjectCollectionResponse();
-            if (json.has("rejectedSenders@odata.nextLink")) {
-                response.nextLink = json.get("rejectedSenders@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("rejectedSenders").toString(), JsonObject[].class);
-            final DirectoryObject[] array = new DirectoryObject[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DirectoryObject.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            rejectedSenders = new DirectoryObjectCollectionPage(response, null);
+            rejectedSenders = serializer.deserializeObject(json.get("rejectedSenders").toString(), DirectoryObjectCollectionPage.class);
         }
 
         if (json.has("threads")) {
-            final ConversationThreadCollectionResponse response = new ConversationThreadCollectionResponse();
-            if (json.has("threads@odata.nextLink")) {
-                response.nextLink = json.get("threads@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("threads").toString(), JsonObject[].class);
-            final ConversationThread[] array = new ConversationThread[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), ConversationThread.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            threads = new ConversationThreadCollectionPage(response, null);
+            threads = serializer.deserializeObject(json.get("threads").toString(), ConversationThreadCollectionPage.class);
         }
 
         if (json.has("drives")) {
-            final DriveCollectionResponse response = new DriveCollectionResponse();
-            if (json.has("drives@odata.nextLink")) {
-                response.nextLink = json.get("drives@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("drives").toString(), JsonObject[].class);
-            final Drive[] array = new Drive[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), Drive.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            drives = new DriveCollectionPage(response, null);
+            drives = serializer.deserializeObject(json.get("drives").toString(), DriveCollectionPage.class);
         }
 
         if (json.has("sites")) {
-            final SiteCollectionResponse response = new SiteCollectionResponse();
-            if (json.has("sites@odata.nextLink")) {
-                response.nextLink = json.get("sites@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("sites").toString(), JsonObject[].class);
-            final Site[] array = new Site[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), Site.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            sites = new SiteCollectionPage(response, null);
+            sites = serializer.deserializeObject(json.get("sites").toString(), SiteCollectionPage.class);
         }
 
         if (json.has("extensions")) {
-            final ExtensionCollectionResponse response = new ExtensionCollectionResponse();
-            if (json.has("extensions@odata.nextLink")) {
-                response.nextLink = json.get("extensions@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("extensions").toString(), JsonObject[].class);
-            final Extension[] array = new Extension[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), Extension.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            extensions = new ExtensionCollectionPage(response, null);
+            extensions = serializer.deserializeObject(json.get("extensions").toString(), ExtensionCollectionPage.class);
         }
 
         if (json.has("groupLifecyclePolicies")) {
-            final GroupLifecyclePolicyCollectionResponse response = new GroupLifecyclePolicyCollectionResponse();
-            if (json.has("groupLifecyclePolicies@odata.nextLink")) {
-                response.nextLink = json.get("groupLifecyclePolicies@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("groupLifecyclePolicies").toString(), JsonObject[].class);
-            final GroupLifecyclePolicy[] array = new GroupLifecyclePolicy[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), GroupLifecyclePolicy.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            groupLifecyclePolicies = new GroupLifecyclePolicyCollectionPage(response, null);
+            groupLifecyclePolicies = serializer.deserializeObject(json.get("groupLifecyclePolicies").toString(), GroupLifecyclePolicyCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/GroupAssignmentTarget.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/GroupAssignmentTarget.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.DeviceAndAppManagementAssignmentTarget;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/GroupLifecyclePolicy.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/GroupLifecyclePolicy.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Entity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/GroupSetting.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/GroupSetting.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.SettingValue;
 import com.microsoft.graph.models.extensions.Entity;

--- a/src/main/java/com/microsoft/graph/models/extensions/GroupSettingTemplate.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/GroupSettingTemplate.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.SettingTemplateValue;
 import com.microsoft.graph.models.extensions.DirectoryObject;

--- a/src/main/java/com/microsoft/graph/models/extensions/Hashes.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Hashes.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/HomeRealmDiscoveryPolicy.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/HomeRealmDiscoveryPolicy.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.StsPolicy;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/HostSecurityState.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/HostSecurityState.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/IPv4CidrRange.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/IPv4CidrRange.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.IpRange;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/IPv4Range.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/IPv4Range.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.IpRange;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/IPv6CidrRange.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/IPv6CidrRange.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.IpRange;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/IPv6Range.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/IPv6Range.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.IpRange;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/Identity.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Identity.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/IdentityContainer.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/IdentityContainer.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.ConditionalAccessRoot;
 import com.microsoft.graph.models.extensions.Entity;

--- a/src/main/java/com/microsoft/graph/models/extensions/IdentityProvider.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/IdentityProvider.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Entity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/IdentitySecurityDefaultsEnforcementPolicy.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/IdentitySecurityDefaultsEnforcementPolicy.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.PolicyBase;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/IdentitySet.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/IdentitySet.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Identity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/Image.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Image.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ImageInfo.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ImageInfo.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ImplicitGrantSettings.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ImplicitGrantSettings.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/IncomingContext.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/IncomingContext.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.IdentitySet;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/IncompleteData.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/IncompleteData.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/InferenceClassification.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/InferenceClassification.java
@@ -6,11 +6,9 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.InferenceClassificationOverride;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.InferenceClassificationOverrideCollectionResponse;
 import com.microsoft.graph.requests.extensions.InferenceClassificationOverrideCollectionPage;
 
 
@@ -75,19 +73,7 @@ public class InferenceClassification extends Entity implements IJsonBackedObject
 
 
         if (json.has("overrides")) {
-            final InferenceClassificationOverrideCollectionResponse response = new InferenceClassificationOverrideCollectionResponse();
-            if (json.has("overrides@odata.nextLink")) {
-                response.nextLink = json.get("overrides@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("overrides").toString(), JsonObject[].class);
-            final InferenceClassificationOverride[] array = new InferenceClassificationOverride[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), InferenceClassificationOverride.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            overrides = new InferenceClassificationOverrideCollectionPage(response, null);
+            overrides = serializer.deserializeObject(json.get("overrides").toString(), InferenceClassificationOverrideCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/InferenceClassificationOverride.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/InferenceClassificationOverride.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.InferenceClassificationType;
 import com.microsoft.graph.models.extensions.EmailAddress;

--- a/src/main/java/com/microsoft/graph/models/extensions/InformationProtection.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/InformationProtection.java
@@ -6,11 +6,9 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.ThreatAssessmentRequest;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.ThreatAssessmentRequestCollectionResponse;
 import com.microsoft.graph.requests.extensions.ThreatAssessmentRequestCollectionPage;
 
 
@@ -75,19 +73,7 @@ public class InformationProtection extends Entity implements IJsonBackedObject {
 
 
         if (json.has("threatAssessmentRequests")) {
-            final ThreatAssessmentRequestCollectionResponse response = new ThreatAssessmentRequestCollectionResponse();
-            if (json.has("threatAssessmentRequests@odata.nextLink")) {
-                response.nextLink = json.get("threatAssessmentRequests@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("threatAssessmentRequests").toString(), JsonObject[].class);
-            final ThreatAssessmentRequest[] array = new ThreatAssessmentRequest[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), ThreatAssessmentRequest.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            threatAssessmentRequests = new ThreatAssessmentRequestCollectionPage(response, null);
+            threatAssessmentRequests = serializer.deserializeObject(json.get("threatAssessmentRequests").toString(), ThreatAssessmentRequestCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/InformationalUrl.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/InformationalUrl.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/InsightIdentity.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/InsightIdentity.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/InternetMessageHeader.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/InternetMessageHeader.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/IntuneBrand.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/IntuneBrand.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.MimeContent;
 import com.microsoft.graph.models.extensions.RgbColor;

--- a/src/main/java/com/microsoft/graph/models/extensions/Invitation.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Invitation.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.InvitedUserMessageInfo;
 import com.microsoft.graph.models.extensions.User;

--- a/src/main/java/com/microsoft/graph/models/extensions/InvitationParticipantInfo.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/InvitationParticipantInfo.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.IdentitySet;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/InviteParticipantsOperation.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/InviteParticipantsOperation.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.InvitationParticipantInfo;
 import com.microsoft.graph.models.extensions.CommsOperation;

--- a/src/main/java/com/microsoft/graph/models/extensions/InvitedUserMessageInfo.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/InvitedUserMessageInfo.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Recipient;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/IosCertificateProfile.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/IosCertificateProfile.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.DeviceConfiguration;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/IosCompliancePolicy.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/IosCompliancePolicy.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.DeviceThreatProtectionLevel;
 import com.microsoft.graph.models.generated.RequiredPasswordType;

--- a/src/main/java/com/microsoft/graph/models/extensions/IosCustomConfiguration.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/IosCustomConfiguration.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.DeviceConfiguration;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/IosDeviceFeaturesConfiguration.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/IosDeviceFeaturesConfiguration.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.IosHomeScreenItem;
 import com.microsoft.graph.models.extensions.IosHomeScreenPage;

--- a/src/main/java/com/microsoft/graph/models/extensions/IosDeviceType.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/IosDeviceType.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/IosGeneralDeviceConfiguration.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/IosGeneralDeviceConfiguration.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.AppListItem;
 import com.microsoft.graph.models.generated.AppListType;

--- a/src/main/java/com/microsoft/graph/models/extensions/IosHomeScreenApp.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/IosHomeScreenApp.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.IosHomeScreenItem;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/IosHomeScreenFolder.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/IosHomeScreenFolder.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.IosHomeScreenFolderPage;
 import com.microsoft.graph.models.extensions.IosHomeScreenItem;

--- a/src/main/java/com/microsoft/graph/models/extensions/IosHomeScreenFolderPage.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/IosHomeScreenFolderPage.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.IosHomeScreenApp;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/IosHomeScreenItem.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/IosHomeScreenItem.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/IosHomeScreenPage.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/IosHomeScreenPage.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.IosHomeScreenItem;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/IosLobApp.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/IosLobApp.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.IosDeviceType;
 import com.microsoft.graph.models.extensions.IosMinimumOperatingSystem;

--- a/src/main/java/com/microsoft/graph/models/extensions/IosLobAppAssignmentSettings.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/IosLobAppAssignmentSettings.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.MobileAppAssignmentSettings;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/IosManagedAppProtection.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/IosManagedAppProtection.java
@@ -6,13 +6,11 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.ManagedAppDataEncryptionType;
 import com.microsoft.graph.models.extensions.ManagedMobileApp;
 import com.microsoft.graph.models.extensions.ManagedAppPolicyDeploymentSummary;
 import com.microsoft.graph.models.extensions.TargetedManagedAppProtection;
-import com.microsoft.graph.requests.extensions.ManagedMobileAppCollectionResponse;
 import com.microsoft.graph.requests.extensions.ManagedMobileAppCollectionPage;
 
 
@@ -125,19 +123,7 @@ public class IosManagedAppProtection extends TargetedManagedAppProtection implem
 
 
         if (json.has("apps")) {
-            final ManagedMobileAppCollectionResponse response = new ManagedMobileAppCollectionResponse();
-            if (json.has("apps@odata.nextLink")) {
-                response.nextLink = json.get("apps@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("apps").toString(), JsonObject[].class);
-            final ManagedMobileApp[] array = new ManagedMobileApp[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), ManagedMobileApp.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            apps = new ManagedMobileAppCollectionPage(response, null);
+            apps = serializer.deserializeObject(json.get("apps").toString(), ManagedMobileAppCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/IosManagedAppRegistration.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/IosManagedAppRegistration.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.ManagedAppRegistration;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/IosMinimumOperatingSystem.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/IosMinimumOperatingSystem.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/IosMobileAppConfiguration.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/IosMobileAppConfiguration.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.AppConfigurationSettingItem;
 import com.microsoft.graph.models.extensions.ManagedDeviceMobileAppConfiguration;

--- a/src/main/java/com/microsoft/graph/models/extensions/IosMobileAppIdentifier.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/IosMobileAppIdentifier.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.MobileAppIdentifier;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/IosNetworkUsageRule.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/IosNetworkUsageRule.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.AppListItem;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/IosNotificationSettings.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/IosNotificationSettings.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.IosNotificationAlertType;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/IosStoreApp.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/IosStoreApp.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.IosDeviceType;
 import com.microsoft.graph.models.extensions.IosMinimumOperatingSystem;

--- a/src/main/java/com/microsoft/graph/models/extensions/IosStoreAppAssignmentSettings.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/IosStoreAppAssignmentSettings.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.MobileAppAssignmentSettings;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/IosUpdateConfiguration.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/IosUpdateConfiguration.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.DayOfWeek;
 import com.microsoft.graph.models.extensions.DeviceConfiguration;

--- a/src/main/java/com/microsoft/graph/models/extensions/IosUpdateDeviceStatus.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/IosUpdateDeviceStatus.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.IosUpdatesInstallStatus;
 import com.microsoft.graph.models.generated.ComplianceStatus;

--- a/src/main/java/com/microsoft/graph/models/extensions/IosVppApp.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/IosVppApp.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.IosDeviceType;
 import com.microsoft.graph.models.extensions.VppLicensingType;

--- a/src/main/java/com/microsoft/graph/models/extensions/IosVppAppAssignmentSettings.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/IosVppAppAssignmentSettings.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.MobileAppAssignmentSettings;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/IosVppEBook.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/IosVppEBook.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.ManagedEBook;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/IosVppEBookAssignment.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/IosVppEBookAssignment.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.ManagedEBookAssignment;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/IpNamedLocation.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/IpNamedLocation.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.IpRange;
 import com.microsoft.graph.models.extensions.NamedLocation;

--- a/src/main/java/com/microsoft/graph/models/extensions/IpRange.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/IpRange.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ItemActionStat.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ItemActionStat.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ItemActivity.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ItemActivity.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.AccessAction;
 import com.microsoft.graph.models.extensions.IdentitySet;

--- a/src/main/java/com/microsoft/graph/models/extensions/ItemActivityStat.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ItemActivityStat.java
@@ -6,13 +6,11 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.ItemActionStat;
 import com.microsoft.graph.models.extensions.IncompleteData;
 import com.microsoft.graph.models.extensions.ItemActivity;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.ItemActivityCollectionResponse;
 import com.microsoft.graph.requests.extensions.ItemActivityCollectionPage;
 
 
@@ -149,19 +147,7 @@ public class ItemActivityStat extends Entity implements IJsonBackedObject {
 
 
         if (json.has("activities")) {
-            final ItemActivityCollectionResponse response = new ItemActivityCollectionResponse();
-            if (json.has("activities@odata.nextLink")) {
-                response.nextLink = json.get("activities@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("activities").toString(), JsonObject[].class);
-            final ItemActivity[] array = new ItemActivity[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), ItemActivity.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            activities = new ItemActivityCollectionPage(response, null);
+            activities = serializer.deserializeObject(json.get("activities").toString(), ItemActivityCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/ItemAnalytics.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ItemAnalytics.java
@@ -6,11 +6,9 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.ItemActivityStat;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.ItemActivityStatCollectionResponse;
 import com.microsoft.graph.requests.extensions.ItemActivityStatCollectionPage;
 
 
@@ -91,19 +89,7 @@ public class ItemAnalytics extends Entity implements IJsonBackedObject {
 
 
         if (json.has("itemActivityStats")) {
-            final ItemActivityStatCollectionResponse response = new ItemActivityStatCollectionResponse();
-            if (json.has("itemActivityStats@odata.nextLink")) {
-                response.nextLink = json.get("itemActivityStats@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("itemActivityStats").toString(), JsonObject[].class);
-            final ItemActivityStat[] array = new ItemActivityStat[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), ItemActivityStat.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            itemActivityStats = new ItemActivityStatCollectionPage(response, null);
+            itemActivityStats = serializer.deserializeObject(json.get("itemActivityStats").toString(), ItemActivityStatCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/ItemAttachment.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ItemAttachment.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.OutlookItem;
 import com.microsoft.graph.models.extensions.Attachment;

--- a/src/main/java/com/microsoft/graph/models/extensions/ItemBody.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ItemBody.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.BodyType;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ItemPreviewInfo.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ItemPreviewInfo.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ItemReference.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ItemReference.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.SharepointIds;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/KeyCredential.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/KeyCredential.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/KeyValue.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/KeyValue.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/KeyValuePair.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/KeyValuePair.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/LicenseAssignmentState.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/LicenseAssignmentState.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/LicenseDetails.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/LicenseDetails.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.ServicePlanInfo;
 import com.microsoft.graph.models.extensions.Entity;

--- a/src/main/java/com/microsoft/graph/models/extensions/LicenseProcessingState.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/LicenseProcessingState.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/LicenseUnitsDetail.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/LicenseUnitsDetail.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/List.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/List.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.ListInfo;
 import com.microsoft.graph.models.extensions.SharepointIds;
@@ -17,13 +16,9 @@ import com.microsoft.graph.models.extensions.Drive;
 import com.microsoft.graph.models.extensions.ListItem;
 import com.microsoft.graph.models.extensions.Subscription;
 import com.microsoft.graph.models.extensions.BaseItem;
-import com.microsoft.graph.requests.extensions.ColumnDefinitionCollectionResponse;
 import com.microsoft.graph.requests.extensions.ColumnDefinitionCollectionPage;
-import com.microsoft.graph.requests.extensions.ContentTypeCollectionResponse;
 import com.microsoft.graph.requests.extensions.ContentTypeCollectionPage;
-import com.microsoft.graph.requests.extensions.ListItemCollectionResponse;
 import com.microsoft.graph.requests.extensions.ListItemCollectionPage;
-import com.microsoft.graph.requests.extensions.SubscriptionCollectionResponse;
 import com.microsoft.graph.requests.extensions.SubscriptionCollectionPage;
 
 
@@ -152,67 +147,19 @@ public class List extends BaseItem implements IJsonBackedObject {
 
 
         if (json.has("columns")) {
-            final ColumnDefinitionCollectionResponse response = new ColumnDefinitionCollectionResponse();
-            if (json.has("columns@odata.nextLink")) {
-                response.nextLink = json.get("columns@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("columns").toString(), JsonObject[].class);
-            final ColumnDefinition[] array = new ColumnDefinition[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), ColumnDefinition.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            columns = new ColumnDefinitionCollectionPage(response, null);
+            columns = serializer.deserializeObject(json.get("columns").toString(), ColumnDefinitionCollectionPage.class);
         }
 
         if (json.has("contentTypes")) {
-            final ContentTypeCollectionResponse response = new ContentTypeCollectionResponse();
-            if (json.has("contentTypes@odata.nextLink")) {
-                response.nextLink = json.get("contentTypes@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("contentTypes").toString(), JsonObject[].class);
-            final ContentType[] array = new ContentType[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), ContentType.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            contentTypes = new ContentTypeCollectionPage(response, null);
+            contentTypes = serializer.deserializeObject(json.get("contentTypes").toString(), ContentTypeCollectionPage.class);
         }
 
         if (json.has("items")) {
-            final ListItemCollectionResponse response = new ListItemCollectionResponse();
-            if (json.has("items@odata.nextLink")) {
-                response.nextLink = json.get("items@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("items").toString(), JsonObject[].class);
-            final ListItem[] array = new ListItem[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), ListItem.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            items = new ListItemCollectionPage(response, null);
+            items = serializer.deserializeObject(json.get("items").toString(), ListItemCollectionPage.class);
         }
 
         if (json.has("subscriptions")) {
-            final SubscriptionCollectionResponse response = new SubscriptionCollectionResponse();
-            if (json.has("subscriptions@odata.nextLink")) {
-                response.nextLink = json.get("subscriptions@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("subscriptions").toString(), JsonObject[].class);
-            final Subscription[] array = new Subscription[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), Subscription.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            subscriptions = new SubscriptionCollectionPage(response, null);
+            subscriptions = serializer.deserializeObject(json.get("subscriptions").toString(), SubscriptionCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/ListInfo.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ListInfo.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ListItem.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ListItem.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.ContentTypeInfo;
 import com.microsoft.graph.models.extensions.SharepointIds;
@@ -15,7 +14,6 @@ import com.microsoft.graph.models.extensions.DriveItem;
 import com.microsoft.graph.models.extensions.FieldValueSet;
 import com.microsoft.graph.models.extensions.ListItemVersion;
 import com.microsoft.graph.models.extensions.BaseItem;
-import com.microsoft.graph.requests.extensions.ListItemVersionCollectionResponse;
 import com.microsoft.graph.requests.extensions.ListItemVersionCollectionPage;
 
 
@@ -120,19 +118,7 @@ public class ListItem extends BaseItem implements IJsonBackedObject {
 
 
         if (json.has("versions")) {
-            final ListItemVersionCollectionResponse response = new ListItemVersionCollectionResponse();
-            if (json.has("versions@odata.nextLink")) {
-                response.nextLink = json.get("versions@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("versions").toString(), JsonObject[].class);
-            final ListItemVersion[] array = new ListItemVersion[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), ListItemVersion.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            versions = new ListItemVersionCollectionPage(response, null);
+            versions = serializer.deserializeObject(json.get("versions").toString(), ListItemVersionCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/ListItemVersion.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ListItemVersion.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.FieldValueSet;
 import com.microsoft.graph.models.extensions.BaseItemVersion;

--- a/src/main/java/com/microsoft/graph/models/extensions/LocaleInfo.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/LocaleInfo.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/LocalizedNotificationMessage.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/LocalizedNotificationMessage.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Entity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/LocateDeviceActionResult.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/LocateDeviceActionResult.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.DeviceGeoLocation;
 import com.microsoft.graph.models.extensions.DeviceActionResult;

--- a/src/main/java/com/microsoft/graph/models/extensions/Location.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Location.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.PhysicalAddress;
 import com.microsoft.graph.models.extensions.OutlookGeoCoordinates;

--- a/src/main/java/com/microsoft/graph/models/extensions/LocationConstraint.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/LocationConstraint.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.LocationConstraintItem;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/LocationConstraintItem.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/LocationConstraintItem.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Location;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/LookupColumn.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/LookupColumn.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/MacOSCompliancePolicy.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/MacOSCompliancePolicy.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.DeviceThreatProtectionLevel;
 import com.microsoft.graph.models.generated.RequiredPasswordType;

--- a/src/main/java/com/microsoft/graph/models/extensions/MacOSCustomConfiguration.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/MacOSCustomConfiguration.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.DeviceConfiguration;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/MacOSDeviceFeaturesConfiguration.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/MacOSDeviceFeaturesConfiguration.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.AppleDeviceFeaturesConfigurationBase;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/MacOSGeneralDeviceConfiguration.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/MacOSGeneralDeviceConfiguration.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.AppListType;
 import com.microsoft.graph.models.extensions.AppListItem;

--- a/src/main/java/com/microsoft/graph/models/extensions/MacOSOfficeSuiteApp.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/MacOSOfficeSuiteApp.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.MobileApp;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/MailAssessmentRequest.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/MailAssessmentRequest.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.MailDestinationRoutingReason;
 import com.microsoft.graph.models.extensions.ThreatAssessmentRequest;

--- a/src/main/java/com/microsoft/graph/models/extensions/MailFolder.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/MailFolder.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.MailFolder;
 import com.microsoft.graph.models.extensions.MessageRule;
@@ -14,15 +13,10 @@ import com.microsoft.graph.models.extensions.Message;
 import com.microsoft.graph.models.extensions.MultiValueLegacyExtendedProperty;
 import com.microsoft.graph.models.extensions.SingleValueLegacyExtendedProperty;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.MailFolderCollectionResponse;
 import com.microsoft.graph.requests.extensions.MailFolderCollectionPage;
-import com.microsoft.graph.requests.extensions.MessageRuleCollectionResponse;
 import com.microsoft.graph.requests.extensions.MessageRuleCollectionPage;
-import com.microsoft.graph.requests.extensions.MessageCollectionResponse;
 import com.microsoft.graph.requests.extensions.MessageCollectionPage;
-import com.microsoft.graph.requests.extensions.MultiValueLegacyExtendedPropertyCollectionResponse;
 import com.microsoft.graph.requests.extensions.MultiValueLegacyExtendedPropertyCollectionPage;
-import com.microsoft.graph.requests.extensions.SingleValueLegacyExtendedPropertyCollectionResponse;
 import com.microsoft.graph.requests.extensions.SingleValueLegacyExtendedPropertyCollectionPage;
 
 
@@ -159,83 +153,23 @@ public class MailFolder extends Entity implements IJsonBackedObject {
 
 
         if (json.has("childFolders")) {
-            final MailFolderCollectionResponse response = new MailFolderCollectionResponse();
-            if (json.has("childFolders@odata.nextLink")) {
-                response.nextLink = json.get("childFolders@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("childFolders").toString(), JsonObject[].class);
-            final MailFolder[] array = new MailFolder[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), MailFolder.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            childFolders = new MailFolderCollectionPage(response, null);
+            childFolders = serializer.deserializeObject(json.get("childFolders").toString(), MailFolderCollectionPage.class);
         }
 
         if (json.has("messageRules")) {
-            final MessageRuleCollectionResponse response = new MessageRuleCollectionResponse();
-            if (json.has("messageRules@odata.nextLink")) {
-                response.nextLink = json.get("messageRules@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("messageRules").toString(), JsonObject[].class);
-            final MessageRule[] array = new MessageRule[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), MessageRule.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            messageRules = new MessageRuleCollectionPage(response, null);
+            messageRules = serializer.deserializeObject(json.get("messageRules").toString(), MessageRuleCollectionPage.class);
         }
 
         if (json.has("messages")) {
-            final MessageCollectionResponse response = new MessageCollectionResponse();
-            if (json.has("messages@odata.nextLink")) {
-                response.nextLink = json.get("messages@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("messages").toString(), JsonObject[].class);
-            final Message[] array = new Message[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), Message.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            messages = new MessageCollectionPage(response, null);
+            messages = serializer.deserializeObject(json.get("messages").toString(), MessageCollectionPage.class);
         }
 
         if (json.has("multiValueExtendedProperties")) {
-            final MultiValueLegacyExtendedPropertyCollectionResponse response = new MultiValueLegacyExtendedPropertyCollectionResponse();
-            if (json.has("multiValueExtendedProperties@odata.nextLink")) {
-                response.nextLink = json.get("multiValueExtendedProperties@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("multiValueExtendedProperties").toString(), JsonObject[].class);
-            final MultiValueLegacyExtendedProperty[] array = new MultiValueLegacyExtendedProperty[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), MultiValueLegacyExtendedProperty.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            multiValueExtendedProperties = new MultiValueLegacyExtendedPropertyCollectionPage(response, null);
+            multiValueExtendedProperties = serializer.deserializeObject(json.get("multiValueExtendedProperties").toString(), MultiValueLegacyExtendedPropertyCollectionPage.class);
         }
 
         if (json.has("singleValueExtendedProperties")) {
-            final SingleValueLegacyExtendedPropertyCollectionResponse response = new SingleValueLegacyExtendedPropertyCollectionResponse();
-            if (json.has("singleValueExtendedProperties@odata.nextLink")) {
-                response.nextLink = json.get("singleValueExtendedProperties@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("singleValueExtendedProperties").toString(), JsonObject[].class);
-            final SingleValueLegacyExtendedProperty[] array = new SingleValueLegacyExtendedProperty[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), SingleValueLegacyExtendedProperty.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            singleValueExtendedProperties = new SingleValueLegacyExtendedPropertyCollectionPage(response, null);
+            singleValueExtendedProperties = serializer.deserializeObject(json.get("singleValueExtendedProperties").toString(), SingleValueLegacyExtendedPropertyCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/MailSearchFolder.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/MailSearchFolder.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.MailFolder;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/MailTips.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/MailTips.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.AutomaticRepliesMailTips;
 import com.microsoft.graph.models.extensions.EmailAddress;

--- a/src/main/java/com/microsoft/graph/models/extensions/MailTipsError.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/MailTipsError.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/MailboxSettings.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/MailboxSettings.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.AutomaticRepliesSetting;
 import com.microsoft.graph.models.generated.DelegateMeetingMessageDeliveryOptions;

--- a/src/main/java/com/microsoft/graph/models/extensions/MalwareState.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/MalwareState.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ManagedAndroidLobApp.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ManagedAndroidLobApp.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.AndroidMinimumOperatingSystem;
 import com.microsoft.graph.models.extensions.ManagedMobileLobApp;

--- a/src/main/java/com/microsoft/graph/models/extensions/ManagedAndroidStoreApp.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ManagedAndroidStoreApp.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.AndroidMinimumOperatingSystem;
 import com.microsoft.graph.models.extensions.ManagedApp;

--- a/src/main/java/com/microsoft/graph/models/extensions/ManagedApp.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ManagedApp.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.ManagedAppAvailability;
 import com.microsoft.graph.models.extensions.MobileApp;

--- a/src/main/java/com/microsoft/graph/models/extensions/ManagedAppConfiguration.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ManagedAppConfiguration.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.KeyValuePair;
 import com.microsoft.graph.models.extensions.ManagedAppPolicy;

--- a/src/main/java/com/microsoft/graph/models/extensions/ManagedAppDiagnosticStatus.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ManagedAppDiagnosticStatus.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ManagedAppOperation.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ManagedAppOperation.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Entity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ManagedAppPolicy.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ManagedAppPolicy.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Entity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ManagedAppPolicyDeploymentSummary.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ManagedAppPolicyDeploymentSummary.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.ManagedAppPolicyDeploymentSummaryPerApp;
 import com.microsoft.graph.models.extensions.Entity;

--- a/src/main/java/com/microsoft/graph/models/extensions/ManagedAppPolicyDeploymentSummaryPerApp.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ManagedAppPolicyDeploymentSummaryPerApp.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.MobileAppIdentifier;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ManagedAppProtection.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ManagedAppProtection.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.ManagedAppDataStorageLocation;
 import com.microsoft.graph.models.generated.ManagedAppDataTransferLevel;

--- a/src/main/java/com/microsoft/graph/models/extensions/ManagedAppRegistration.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ManagedAppRegistration.java
@@ -6,16 +6,13 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.MobileAppIdentifier;
 import com.microsoft.graph.models.generated.ManagedAppFlaggedReason;
 import com.microsoft.graph.models.extensions.ManagedAppPolicy;
 import com.microsoft.graph.models.extensions.ManagedAppOperation;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.ManagedAppPolicyCollectionResponse;
 import com.microsoft.graph.requests.extensions.ManagedAppPolicyCollectionPage;
-import com.microsoft.graph.requests.extensions.ManagedAppOperationCollectionResponse;
 import com.microsoft.graph.requests.extensions.ManagedAppOperationCollectionPage;
 
 
@@ -192,51 +189,15 @@ public class ManagedAppRegistration extends Entity implements IJsonBackedObject 
 
 
         if (json.has("appliedPolicies")) {
-            final ManagedAppPolicyCollectionResponse response = new ManagedAppPolicyCollectionResponse();
-            if (json.has("appliedPolicies@odata.nextLink")) {
-                response.nextLink = json.get("appliedPolicies@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("appliedPolicies").toString(), JsonObject[].class);
-            final ManagedAppPolicy[] array = new ManagedAppPolicy[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), ManagedAppPolicy.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            appliedPolicies = new ManagedAppPolicyCollectionPage(response, null);
+            appliedPolicies = serializer.deserializeObject(json.get("appliedPolicies").toString(), ManagedAppPolicyCollectionPage.class);
         }
 
         if (json.has("intendedPolicies")) {
-            final ManagedAppPolicyCollectionResponse response = new ManagedAppPolicyCollectionResponse();
-            if (json.has("intendedPolicies@odata.nextLink")) {
-                response.nextLink = json.get("intendedPolicies@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("intendedPolicies").toString(), JsonObject[].class);
-            final ManagedAppPolicy[] array = new ManagedAppPolicy[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), ManagedAppPolicy.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            intendedPolicies = new ManagedAppPolicyCollectionPage(response, null);
+            intendedPolicies = serializer.deserializeObject(json.get("intendedPolicies").toString(), ManagedAppPolicyCollectionPage.class);
         }
 
         if (json.has("operations")) {
-            final ManagedAppOperationCollectionResponse response = new ManagedAppOperationCollectionResponse();
-            if (json.has("operations@odata.nextLink")) {
-                response.nextLink = json.get("operations@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("operations").toString(), JsonObject[].class);
-            final ManagedAppOperation[] array = new ManagedAppOperation[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), ManagedAppOperation.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            operations = new ManagedAppOperationCollectionPage(response, null);
+            operations = serializer.deserializeObject(json.get("operations").toString(), ManagedAppOperationCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/ManagedAppStatus.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ManagedAppStatus.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Entity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ManagedAppStatusRaw.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ManagedAppStatusRaw.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.ManagedAppStatus;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ManagedDevice.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ManagedDevice.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.ComplianceState;
 import com.microsoft.graph.models.extensions.ConfigurationManagerClientEnabledFeatures;
@@ -23,9 +22,7 @@ import com.microsoft.graph.models.extensions.DeviceCompliancePolicyState;
 import com.microsoft.graph.models.extensions.DeviceConfigurationState;
 import com.microsoft.graph.models.extensions.DeviceCategory;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.DeviceCompliancePolicyStateCollectionResponse;
 import com.microsoft.graph.requests.extensions.DeviceCompliancePolicyStateCollectionPage;
-import com.microsoft.graph.requests.extensions.DeviceConfigurationStateCollectionResponse;
 import com.microsoft.graph.requests.extensions.DeviceConfigurationStateCollectionPage;
 
 
@@ -474,35 +471,11 @@ public class ManagedDevice extends Entity implements IJsonBackedObject {
 
 
         if (json.has("deviceCompliancePolicyStates")) {
-            final DeviceCompliancePolicyStateCollectionResponse response = new DeviceCompliancePolicyStateCollectionResponse();
-            if (json.has("deviceCompliancePolicyStates@odata.nextLink")) {
-                response.nextLink = json.get("deviceCompliancePolicyStates@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("deviceCompliancePolicyStates").toString(), JsonObject[].class);
-            final DeviceCompliancePolicyState[] array = new DeviceCompliancePolicyState[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DeviceCompliancePolicyState.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            deviceCompliancePolicyStates = new DeviceCompliancePolicyStateCollectionPage(response, null);
+            deviceCompliancePolicyStates = serializer.deserializeObject(json.get("deviceCompliancePolicyStates").toString(), DeviceCompliancePolicyStateCollectionPage.class);
         }
 
         if (json.has("deviceConfigurationStates")) {
-            final DeviceConfigurationStateCollectionResponse response = new DeviceConfigurationStateCollectionResponse();
-            if (json.has("deviceConfigurationStates@odata.nextLink")) {
-                response.nextLink = json.get("deviceConfigurationStates@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("deviceConfigurationStates").toString(), JsonObject[].class);
-            final DeviceConfigurationState[] array = new DeviceConfigurationState[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DeviceConfigurationState.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            deviceConfigurationStates = new DeviceConfigurationStateCollectionPage(response, null);
+            deviceConfigurationStates = serializer.deserializeObject(json.get("deviceConfigurationStates").toString(), DeviceConfigurationStateCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/ManagedDeviceMobileAppConfiguration.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ManagedDeviceMobileAppConfiguration.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.ManagedDeviceMobileAppConfigurationAssignment;
 import com.microsoft.graph.models.extensions.ManagedDeviceMobileAppConfigurationDeviceStatus;
@@ -14,11 +13,8 @@ import com.microsoft.graph.models.extensions.ManagedDeviceMobileAppConfiguration
 import com.microsoft.graph.models.extensions.ManagedDeviceMobileAppConfigurationUserStatus;
 import com.microsoft.graph.models.extensions.ManagedDeviceMobileAppConfigurationUserSummary;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.ManagedDeviceMobileAppConfigurationAssignmentCollectionResponse;
 import com.microsoft.graph.requests.extensions.ManagedDeviceMobileAppConfigurationAssignmentCollectionPage;
-import com.microsoft.graph.requests.extensions.ManagedDeviceMobileAppConfigurationDeviceStatusCollectionResponse;
 import com.microsoft.graph.requests.extensions.ManagedDeviceMobileAppConfigurationDeviceStatusCollectionPage;
-import com.microsoft.graph.requests.extensions.ManagedDeviceMobileAppConfigurationUserStatusCollectionResponse;
 import com.microsoft.graph.requests.extensions.ManagedDeviceMobileAppConfigurationUserStatusCollectionPage;
 
 
@@ -163,51 +159,15 @@ public class ManagedDeviceMobileAppConfiguration extends Entity implements IJson
 
 
         if (json.has("assignments")) {
-            final ManagedDeviceMobileAppConfigurationAssignmentCollectionResponse response = new ManagedDeviceMobileAppConfigurationAssignmentCollectionResponse();
-            if (json.has("assignments@odata.nextLink")) {
-                response.nextLink = json.get("assignments@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("assignments").toString(), JsonObject[].class);
-            final ManagedDeviceMobileAppConfigurationAssignment[] array = new ManagedDeviceMobileAppConfigurationAssignment[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), ManagedDeviceMobileAppConfigurationAssignment.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            assignments = new ManagedDeviceMobileAppConfigurationAssignmentCollectionPage(response, null);
+            assignments = serializer.deserializeObject(json.get("assignments").toString(), ManagedDeviceMobileAppConfigurationAssignmentCollectionPage.class);
         }
 
         if (json.has("deviceStatuses")) {
-            final ManagedDeviceMobileAppConfigurationDeviceStatusCollectionResponse response = new ManagedDeviceMobileAppConfigurationDeviceStatusCollectionResponse();
-            if (json.has("deviceStatuses@odata.nextLink")) {
-                response.nextLink = json.get("deviceStatuses@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("deviceStatuses").toString(), JsonObject[].class);
-            final ManagedDeviceMobileAppConfigurationDeviceStatus[] array = new ManagedDeviceMobileAppConfigurationDeviceStatus[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), ManagedDeviceMobileAppConfigurationDeviceStatus.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            deviceStatuses = new ManagedDeviceMobileAppConfigurationDeviceStatusCollectionPage(response, null);
+            deviceStatuses = serializer.deserializeObject(json.get("deviceStatuses").toString(), ManagedDeviceMobileAppConfigurationDeviceStatusCollectionPage.class);
         }
 
         if (json.has("userStatuses")) {
-            final ManagedDeviceMobileAppConfigurationUserStatusCollectionResponse response = new ManagedDeviceMobileAppConfigurationUserStatusCollectionResponse();
-            if (json.has("userStatuses@odata.nextLink")) {
-                response.nextLink = json.get("userStatuses@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("userStatuses").toString(), JsonObject[].class);
-            final ManagedDeviceMobileAppConfigurationUserStatus[] array = new ManagedDeviceMobileAppConfigurationUserStatus[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), ManagedDeviceMobileAppConfigurationUserStatus.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            userStatuses = new ManagedDeviceMobileAppConfigurationUserStatusCollectionPage(response, null);
+            userStatuses = serializer.deserializeObject(json.get("userStatuses").toString(), ManagedDeviceMobileAppConfigurationUserStatusCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/ManagedDeviceMobileAppConfigurationAssignment.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ManagedDeviceMobileAppConfigurationAssignment.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.DeviceAndAppManagementAssignmentTarget;
 import com.microsoft.graph.models.extensions.Entity;

--- a/src/main/java/com/microsoft/graph/models/extensions/ManagedDeviceMobileAppConfigurationDeviceStatus.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ManagedDeviceMobileAppConfigurationDeviceStatus.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.ComplianceStatus;
 import com.microsoft.graph.models.extensions.Entity;

--- a/src/main/java/com/microsoft/graph/models/extensions/ManagedDeviceMobileAppConfigurationDeviceSummary.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ManagedDeviceMobileAppConfigurationDeviceSummary.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Entity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ManagedDeviceMobileAppConfigurationUserStatus.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ManagedDeviceMobileAppConfigurationUserStatus.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.ComplianceStatus;
 import com.microsoft.graph.models.extensions.Entity;

--- a/src/main/java/com/microsoft/graph/models/extensions/ManagedDeviceMobileAppConfigurationUserSummary.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ManagedDeviceMobileAppConfigurationUserSummary.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Entity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ManagedDeviceOverview.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ManagedDeviceOverview.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.DeviceExchangeAccessStateSummary;
 import com.microsoft.graph.models.extensions.DeviceOperatingSystemSummary;

--- a/src/main/java/com/microsoft/graph/models/extensions/ManagedEBook.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ManagedEBook.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.MimeContent;
 import com.microsoft.graph.models.extensions.ManagedEBookAssignment;
@@ -14,11 +13,8 @@ import com.microsoft.graph.models.extensions.DeviceInstallState;
 import com.microsoft.graph.models.extensions.EBookInstallSummary;
 import com.microsoft.graph.models.extensions.UserInstallStateSummary;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.ManagedEBookAssignmentCollectionResponse;
 import com.microsoft.graph.requests.extensions.ManagedEBookAssignmentCollectionPage;
-import com.microsoft.graph.requests.extensions.DeviceInstallStateCollectionResponse;
 import com.microsoft.graph.requests.extensions.DeviceInstallStateCollectionPage;
-import com.microsoft.graph.requests.extensions.UserInstallStateSummaryCollectionResponse;
 import com.microsoft.graph.requests.extensions.UserInstallStateSummaryCollectionPage;
 
 
@@ -179,51 +175,15 @@ public class ManagedEBook extends Entity implements IJsonBackedObject {
 
 
         if (json.has("assignments")) {
-            final ManagedEBookAssignmentCollectionResponse response = new ManagedEBookAssignmentCollectionResponse();
-            if (json.has("assignments@odata.nextLink")) {
-                response.nextLink = json.get("assignments@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("assignments").toString(), JsonObject[].class);
-            final ManagedEBookAssignment[] array = new ManagedEBookAssignment[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), ManagedEBookAssignment.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            assignments = new ManagedEBookAssignmentCollectionPage(response, null);
+            assignments = serializer.deserializeObject(json.get("assignments").toString(), ManagedEBookAssignmentCollectionPage.class);
         }
 
         if (json.has("deviceStates")) {
-            final DeviceInstallStateCollectionResponse response = new DeviceInstallStateCollectionResponse();
-            if (json.has("deviceStates@odata.nextLink")) {
-                response.nextLink = json.get("deviceStates@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("deviceStates").toString(), JsonObject[].class);
-            final DeviceInstallState[] array = new DeviceInstallState[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DeviceInstallState.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            deviceStates = new DeviceInstallStateCollectionPage(response, null);
+            deviceStates = serializer.deserializeObject(json.get("deviceStates").toString(), DeviceInstallStateCollectionPage.class);
         }
 
         if (json.has("userStateSummary")) {
-            final UserInstallStateSummaryCollectionResponse response = new UserInstallStateSummaryCollectionResponse();
-            if (json.has("userStateSummary@odata.nextLink")) {
-                response.nextLink = json.get("userStateSummary@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("userStateSummary").toString(), JsonObject[].class);
-            final UserInstallStateSummary[] array = new UserInstallStateSummary[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), UserInstallStateSummary.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            userStateSummary = new UserInstallStateSummaryCollectionPage(response, null);
+            userStateSummary = serializer.deserializeObject(json.get("userStateSummary").toString(), UserInstallStateSummaryCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/ManagedEBookAssignment.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ManagedEBookAssignment.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.InstallIntent;
 import com.microsoft.graph.models.extensions.DeviceAndAppManagementAssignmentTarget;

--- a/src/main/java/com/microsoft/graph/models/extensions/ManagedIOSLobApp.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ManagedIOSLobApp.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.IosDeviceType;
 import com.microsoft.graph.models.extensions.IosMinimumOperatingSystem;

--- a/src/main/java/com/microsoft/graph/models/extensions/ManagedIOSStoreApp.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ManagedIOSStoreApp.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.IosDeviceType;
 import com.microsoft.graph.models.extensions.IosMinimumOperatingSystem;

--- a/src/main/java/com/microsoft/graph/models/extensions/ManagedMobileApp.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ManagedMobileApp.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.MobileAppIdentifier;
 import com.microsoft.graph.models.extensions.Entity;

--- a/src/main/java/com/microsoft/graph/models/extensions/ManagedMobileLobApp.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ManagedMobileLobApp.java
@@ -6,11 +6,9 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.MobileAppContent;
 import com.microsoft.graph.models.extensions.ManagedApp;
-import com.microsoft.graph.requests.extensions.MobileAppContentCollectionResponse;
 import com.microsoft.graph.requests.extensions.MobileAppContentCollectionPage;
 
 
@@ -99,19 +97,7 @@ public class ManagedMobileLobApp extends ManagedApp implements IJsonBackedObject
 
 
         if (json.has("contentVersions")) {
-            final MobileAppContentCollectionResponse response = new MobileAppContentCollectionResponse();
-            if (json.has("contentVersions@odata.nextLink")) {
-                response.nextLink = json.get("contentVersions@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("contentVersions").toString(), JsonObject[].class);
-            final MobileAppContent[] array = new MobileAppContent[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), MobileAppContent.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            contentVersions = new MobileAppContentCollectionPage(response, null);
+            contentVersions = serializer.deserializeObject(json.get("contentVersions").toString(), MobileAppContentCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/MdmWindowsInformationProtectionPolicy.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/MdmWindowsInformationProtectionPolicy.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.WindowsInformationProtection;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/MediaConfig.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/MediaConfig.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/MediaContentRatingAustralia.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/MediaContentRatingAustralia.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.RatingAustraliaMoviesType;
 import com.microsoft.graph.models.generated.RatingAustraliaTelevisionType;

--- a/src/main/java/com/microsoft/graph/models/extensions/MediaContentRatingCanada.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/MediaContentRatingCanada.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.RatingCanadaMoviesType;
 import com.microsoft.graph.models.generated.RatingCanadaTelevisionType;

--- a/src/main/java/com/microsoft/graph/models/extensions/MediaContentRatingFrance.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/MediaContentRatingFrance.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.RatingFranceMoviesType;
 import com.microsoft.graph.models.generated.RatingFranceTelevisionType;

--- a/src/main/java/com/microsoft/graph/models/extensions/MediaContentRatingGermany.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/MediaContentRatingGermany.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.RatingGermanyMoviesType;
 import com.microsoft.graph.models.generated.RatingGermanyTelevisionType;

--- a/src/main/java/com/microsoft/graph/models/extensions/MediaContentRatingIreland.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/MediaContentRatingIreland.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.RatingIrelandMoviesType;
 import com.microsoft.graph.models.generated.RatingIrelandTelevisionType;

--- a/src/main/java/com/microsoft/graph/models/extensions/MediaContentRatingJapan.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/MediaContentRatingJapan.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.RatingJapanMoviesType;
 import com.microsoft.graph.models.generated.RatingJapanTelevisionType;

--- a/src/main/java/com/microsoft/graph/models/extensions/MediaContentRatingNewZealand.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/MediaContentRatingNewZealand.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.RatingNewZealandMoviesType;
 import com.microsoft.graph.models.generated.RatingNewZealandTelevisionType;

--- a/src/main/java/com/microsoft/graph/models/extensions/MediaContentRatingUnitedKingdom.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/MediaContentRatingUnitedKingdom.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.RatingUnitedKingdomMoviesType;
 import com.microsoft.graph.models.generated.RatingUnitedKingdomTelevisionType;

--- a/src/main/java/com/microsoft/graph/models/extensions/MediaContentRatingUnitedStates.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/MediaContentRatingUnitedStates.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.RatingUnitedStatesMoviesType;
 import com.microsoft.graph.models.generated.RatingUnitedStatesTelevisionType;

--- a/src/main/java/com/microsoft/graph/models/extensions/MediaInfo.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/MediaInfo.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/MediaPrompt.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/MediaPrompt.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.MediaInfo;
 import com.microsoft.graph.models.extensions.Prompt;

--- a/src/main/java/com/microsoft/graph/models/extensions/MediaStream.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/MediaStream.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.MediaDirection;
 import com.microsoft.graph.models.generated.Modality;

--- a/src/main/java/com/microsoft/graph/models/extensions/MeetingInfo.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/MeetingInfo.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/MeetingParticipantInfo.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/MeetingParticipantInfo.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.IdentitySet;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/MeetingParticipants.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/MeetingParticipants.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.MeetingParticipantInfo;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/MeetingTimeSuggestion.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/MeetingTimeSuggestion.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.AttendeeAvailability;
 import com.microsoft.graph.models.extensions.Location;

--- a/src/main/java/com/microsoft/graph/models/extensions/MeetingTimeSuggestionsResult.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/MeetingTimeSuggestionsResult.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.MeetingTimeSuggestion;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/Message.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Message.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Recipient;
 import com.microsoft.graph.models.extensions.ItemBody;
@@ -19,13 +18,9 @@ import com.microsoft.graph.models.extensions.Extension;
 import com.microsoft.graph.models.extensions.MultiValueLegacyExtendedProperty;
 import com.microsoft.graph.models.extensions.SingleValueLegacyExtendedProperty;
 import com.microsoft.graph.models.extensions.OutlookItem;
-import com.microsoft.graph.requests.extensions.AttachmentCollectionResponse;
 import com.microsoft.graph.requests.extensions.AttachmentCollectionPage;
-import com.microsoft.graph.requests.extensions.ExtensionCollectionResponse;
 import com.microsoft.graph.requests.extensions.ExtensionCollectionPage;
-import com.microsoft.graph.requests.extensions.MultiValueLegacyExtendedPropertyCollectionResponse;
 import com.microsoft.graph.requests.extensions.MultiValueLegacyExtendedPropertyCollectionPage;
-import com.microsoft.graph.requests.extensions.SingleValueLegacyExtendedPropertyCollectionResponse;
 import com.microsoft.graph.requests.extensions.SingleValueLegacyExtendedPropertyCollectionPage;
 
 
@@ -322,67 +317,19 @@ public class Message extends OutlookItem implements IJsonBackedObject {
 
 
         if (json.has("attachments")) {
-            final AttachmentCollectionResponse response = new AttachmentCollectionResponse();
-            if (json.has("attachments@odata.nextLink")) {
-                response.nextLink = json.get("attachments@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("attachments").toString(), JsonObject[].class);
-            final Attachment[] array = new Attachment[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), Attachment.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            attachments = new AttachmentCollectionPage(response, null);
+            attachments = serializer.deserializeObject(json.get("attachments").toString(), AttachmentCollectionPage.class);
         }
 
         if (json.has("extensions")) {
-            final ExtensionCollectionResponse response = new ExtensionCollectionResponse();
-            if (json.has("extensions@odata.nextLink")) {
-                response.nextLink = json.get("extensions@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("extensions").toString(), JsonObject[].class);
-            final Extension[] array = new Extension[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), Extension.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            extensions = new ExtensionCollectionPage(response, null);
+            extensions = serializer.deserializeObject(json.get("extensions").toString(), ExtensionCollectionPage.class);
         }
 
         if (json.has("multiValueExtendedProperties")) {
-            final MultiValueLegacyExtendedPropertyCollectionResponse response = new MultiValueLegacyExtendedPropertyCollectionResponse();
-            if (json.has("multiValueExtendedProperties@odata.nextLink")) {
-                response.nextLink = json.get("multiValueExtendedProperties@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("multiValueExtendedProperties").toString(), JsonObject[].class);
-            final MultiValueLegacyExtendedProperty[] array = new MultiValueLegacyExtendedProperty[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), MultiValueLegacyExtendedProperty.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            multiValueExtendedProperties = new MultiValueLegacyExtendedPropertyCollectionPage(response, null);
+            multiValueExtendedProperties = serializer.deserializeObject(json.get("multiValueExtendedProperties").toString(), MultiValueLegacyExtendedPropertyCollectionPage.class);
         }
 
         if (json.has("singleValueExtendedProperties")) {
-            final SingleValueLegacyExtendedPropertyCollectionResponse response = new SingleValueLegacyExtendedPropertyCollectionResponse();
-            if (json.has("singleValueExtendedProperties@odata.nextLink")) {
-                response.nextLink = json.get("singleValueExtendedProperties@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("singleValueExtendedProperties").toString(), JsonObject[].class);
-            final SingleValueLegacyExtendedProperty[] array = new SingleValueLegacyExtendedProperty[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), SingleValueLegacyExtendedProperty.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            singleValueExtendedProperties = new SingleValueLegacyExtendedPropertyCollectionPage(response, null);
+            singleValueExtendedProperties = serializer.deserializeObject(json.get("singleValueExtendedProperties").toString(), SingleValueLegacyExtendedPropertyCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/MessageRule.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/MessageRule.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.MessageRuleActions;
 import com.microsoft.graph.models.extensions.MessageRulePredicates;

--- a/src/main/java/com/microsoft/graph/models/extensions/MessageRuleActions.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/MessageRuleActions.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Recipient;
 import com.microsoft.graph.models.generated.Importance;

--- a/src/main/java/com/microsoft/graph/models/extensions/MessageRulePredicates.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/MessageRulePredicates.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Recipient;
 import com.microsoft.graph.models.generated.Importance;

--- a/src/main/java/com/microsoft/graph/models/extensions/MicrosoftStoreForBusinessApp.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/MicrosoftStoreForBusinessApp.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.MicrosoftStoreForBusinessLicenseType;
 import com.microsoft.graph.models.extensions.MobileApp;

--- a/src/main/java/com/microsoft/graph/models/extensions/MicrosoftStoreForBusinessAppAssignmentSettings.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/MicrosoftStoreForBusinessAppAssignmentSettings.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.MobileAppAssignmentSettings;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/MimeContent.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/MimeContent.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/MobileApp.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/MobileApp.java
@@ -6,16 +6,13 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.MimeContent;
 import com.microsoft.graph.models.generated.MobileAppPublishingState;
 import com.microsoft.graph.models.extensions.MobileAppAssignment;
 import com.microsoft.graph.models.extensions.MobileAppCategory;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.MobileAppAssignmentCollectionResponse;
 import com.microsoft.graph.requests.extensions.MobileAppAssignmentCollectionPage;
-import com.microsoft.graph.requests.extensions.MobileAppCategoryCollectionResponse;
 import com.microsoft.graph.requests.extensions.MobileAppCategoryCollectionPage;
 
 
@@ -190,35 +187,11 @@ public class MobileApp extends Entity implements IJsonBackedObject {
 
 
         if (json.has("assignments")) {
-            final MobileAppAssignmentCollectionResponse response = new MobileAppAssignmentCollectionResponse();
-            if (json.has("assignments@odata.nextLink")) {
-                response.nextLink = json.get("assignments@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("assignments").toString(), JsonObject[].class);
-            final MobileAppAssignment[] array = new MobileAppAssignment[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), MobileAppAssignment.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            assignments = new MobileAppAssignmentCollectionPage(response, null);
+            assignments = serializer.deserializeObject(json.get("assignments").toString(), MobileAppAssignmentCollectionPage.class);
         }
 
         if (json.has("categories")) {
-            final MobileAppCategoryCollectionResponse response = new MobileAppCategoryCollectionResponse();
-            if (json.has("categories@odata.nextLink")) {
-                response.nextLink = json.get("categories@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("categories").toString(), JsonObject[].class);
-            final MobileAppCategory[] array = new MobileAppCategory[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), MobileAppCategory.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            categories = new MobileAppCategoryCollectionPage(response, null);
+            categories = serializer.deserializeObject(json.get("categories").toString(), MobileAppCategoryCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/MobileAppAssignment.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/MobileAppAssignment.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.InstallIntent;
 import com.microsoft.graph.models.extensions.MobileAppAssignmentSettings;

--- a/src/main/java/com/microsoft/graph/models/extensions/MobileAppAssignmentSettings.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/MobileAppAssignmentSettings.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/MobileAppCategory.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/MobileAppCategory.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Entity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/MobileAppContent.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/MobileAppContent.java
@@ -6,11 +6,9 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.MobileAppContentFile;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.MobileAppContentFileCollectionResponse;
 import com.microsoft.graph.requests.extensions.MobileAppContentFileCollectionPage;
 
 
@@ -75,19 +73,7 @@ public class MobileAppContent extends Entity implements IJsonBackedObject {
 
 
         if (json.has("files")) {
-            final MobileAppContentFileCollectionResponse response = new MobileAppContentFileCollectionResponse();
-            if (json.has("files@odata.nextLink")) {
-                response.nextLink = json.get("files@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("files").toString(), JsonObject[].class);
-            final MobileAppContentFile[] array = new MobileAppContentFile[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), MobileAppContentFile.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            files = new MobileAppContentFileCollectionPage(response, null);
+            files = serializer.deserializeObject(json.get("files").toString(), MobileAppContentFileCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/MobileAppContentFile.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/MobileAppContentFile.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.MobileAppContentFileUploadState;
 import com.microsoft.graph.models.extensions.Entity;

--- a/src/main/java/com/microsoft/graph/models/extensions/MobileAppIdentifier.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/MobileAppIdentifier.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/MobileAppInstallTimeSettings.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/MobileAppInstallTimeSettings.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/MobileLobApp.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/MobileLobApp.java
@@ -6,11 +6,9 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.MobileAppContent;
 import com.microsoft.graph.models.extensions.MobileApp;
-import com.microsoft.graph.requests.extensions.MobileAppContentCollectionResponse;
 import com.microsoft.graph.requests.extensions.MobileAppContentCollectionPage;
 
 
@@ -99,19 +97,7 @@ public class MobileLobApp extends MobileApp implements IJsonBackedObject {
 
 
         if (json.has("contentVersions")) {
-            final MobileAppContentCollectionResponse response = new MobileAppContentCollectionResponse();
-            if (json.has("contentVersions@odata.nextLink")) {
-                response.nextLink = json.get("contentVersions@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("contentVersions").toString(), JsonObject[].class);
-            final MobileAppContent[] array = new MobileAppContent[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), MobileAppContent.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            contentVersions = new MobileAppContentCollectionPage(response, null);
+            contentVersions = serializer.deserializeObject(json.get("contentVersions").toString(), MobileAppContentCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/MobileThreatDefenseConnector.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/MobileThreatDefenseConnector.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.MobileThreatPartnerTenantState;
 import com.microsoft.graph.models.extensions.Entity;

--- a/src/main/java/com/microsoft/graph/models/extensions/ModifiedProperty.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ModifiedProperty.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/MultiValueLegacyExtendedProperty.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/MultiValueLegacyExtendedProperty.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Entity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/MuteParticipantOperation.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/MuteParticipantOperation.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.CommsOperation;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/NamedLocation.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/NamedLocation.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Entity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/NetworkConnection.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/NetworkConnection.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.ConnectionDirection;
 import com.microsoft.graph.models.generated.SecurityNetworkProtocol;

--- a/src/main/java/com/microsoft/graph/models/extensions/Notebook.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Notebook.java
@@ -6,16 +6,13 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.NotebookLinks;
 import com.microsoft.graph.models.generated.OnenoteUserRole;
 import com.microsoft.graph.models.extensions.SectionGroup;
 import com.microsoft.graph.models.extensions.OnenoteSection;
 import com.microsoft.graph.models.extensions.OnenoteEntityHierarchyModel;
-import com.microsoft.graph.requests.extensions.SectionGroupCollectionResponse;
 import com.microsoft.graph.requests.extensions.SectionGroupCollectionPage;
-import com.microsoft.graph.requests.extensions.OnenoteSectionCollectionResponse;
 import com.microsoft.graph.requests.extensions.OnenoteSectionCollectionPage;
 
 
@@ -136,35 +133,11 @@ public class Notebook extends OnenoteEntityHierarchyModel implements IJsonBacked
 
 
         if (json.has("sectionGroups")) {
-            final SectionGroupCollectionResponse response = new SectionGroupCollectionResponse();
-            if (json.has("sectionGroups@odata.nextLink")) {
-                response.nextLink = json.get("sectionGroups@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("sectionGroups").toString(), JsonObject[].class);
-            final SectionGroup[] array = new SectionGroup[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), SectionGroup.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            sectionGroups = new SectionGroupCollectionPage(response, null);
+            sectionGroups = serializer.deserializeObject(json.get("sectionGroups").toString(), SectionGroupCollectionPage.class);
         }
 
         if (json.has("sections")) {
-            final OnenoteSectionCollectionResponse response = new OnenoteSectionCollectionResponse();
-            if (json.has("sections@odata.nextLink")) {
-                response.nextLink = json.get("sections@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("sections").toString(), JsonObject[].class);
-            final OnenoteSection[] array = new OnenoteSection[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), OnenoteSection.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            sections = new OnenoteSectionCollectionPage(response, null);
+            sections = serializer.deserializeObject(json.get("sections").toString(), OnenoteSectionCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/NotebookLinks.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/NotebookLinks.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.ExternalLink;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/NotificationMessageTemplate.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/NotificationMessageTemplate.java
@@ -6,12 +6,10 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.NotificationTemplateBrandingOptions;
 import com.microsoft.graph.models.extensions.LocalizedNotificationMessage;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.LocalizedNotificationMessageCollectionResponse;
 import com.microsoft.graph.requests.extensions.LocalizedNotificationMessageCollectionPage;
 
 
@@ -108,19 +106,7 @@ public class NotificationMessageTemplate extends Entity implements IJsonBackedOb
 
 
         if (json.has("localizedNotificationMessages")) {
-            final LocalizedNotificationMessageCollectionResponse response = new LocalizedNotificationMessageCollectionResponse();
-            if (json.has("localizedNotificationMessages@odata.nextLink")) {
-                response.nextLink = json.get("localizedNotificationMessages@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("localizedNotificationMessages").toString(), JsonObject[].class);
-            final LocalizedNotificationMessage[] array = new LocalizedNotificationMessage[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), LocalizedNotificationMessage.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            localizedNotificationMessages = new LocalizedNotificationMessageCollectionPage(response, null);
+            localizedNotificationMessages = serializer.deserializeObject(json.get("localizedNotificationMessages").toString(), LocalizedNotificationMessageCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/NumberColumn.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/NumberColumn.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/OAuth2PermissionGrant.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/OAuth2PermissionGrant.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Entity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ObjectIdentity.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ObjectIdentity.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/OfferShiftRequest.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/OfferShiftRequest.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.ScheduleChangeRequest;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/OfficeGraphInsights.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/OfficeGraphInsights.java
@@ -6,17 +6,13 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.SharedInsight;
 import com.microsoft.graph.models.extensions.Trending;
 import com.microsoft.graph.models.extensions.UsedInsight;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.SharedInsightCollectionResponse;
 import com.microsoft.graph.requests.extensions.SharedInsightCollectionPage;
-import com.microsoft.graph.requests.extensions.TrendingCollectionResponse;
 import com.microsoft.graph.requests.extensions.TrendingCollectionPage;
-import com.microsoft.graph.requests.extensions.UsedInsightCollectionResponse;
 import com.microsoft.graph.requests.extensions.UsedInsightCollectionPage;
 
 
@@ -97,51 +93,15 @@ public class OfficeGraphInsights extends Entity implements IJsonBackedObject {
 
 
         if (json.has("shared")) {
-            final SharedInsightCollectionResponse response = new SharedInsightCollectionResponse();
-            if (json.has("shared@odata.nextLink")) {
-                response.nextLink = json.get("shared@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("shared").toString(), JsonObject[].class);
-            final SharedInsight[] array = new SharedInsight[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), SharedInsight.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            shared = new SharedInsightCollectionPage(response, null);
+            shared = serializer.deserializeObject(json.get("shared").toString(), SharedInsightCollectionPage.class);
         }
 
         if (json.has("trending")) {
-            final TrendingCollectionResponse response = new TrendingCollectionResponse();
-            if (json.has("trending@odata.nextLink")) {
-                response.nextLink = json.get("trending@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("trending").toString(), JsonObject[].class);
-            final Trending[] array = new Trending[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), Trending.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            trending = new TrendingCollectionPage(response, null);
+            trending = serializer.deserializeObject(json.get("trending").toString(), TrendingCollectionPage.class);
         }
 
         if (json.has("used")) {
-            final UsedInsightCollectionResponse response = new UsedInsightCollectionResponse();
-            if (json.has("used@odata.nextLink")) {
-                response.nextLink = json.get("used@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("used").toString(), JsonObject[].class);
-            final UsedInsight[] array = new UsedInsight[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), UsedInsight.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            used = new UsedInsightCollectionPage(response, null);
+            used = serializer.deserializeObject(json.get("used").toString(), UsedInsightCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/OmaSetting.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/OmaSetting.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/OmaSettingBase64.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/OmaSettingBase64.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.OmaSetting;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/OmaSettingBoolean.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/OmaSettingBoolean.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.OmaSetting;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/OmaSettingDateTime.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/OmaSettingDateTime.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.OmaSetting;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/OmaSettingFloatingPoint.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/OmaSettingFloatingPoint.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.OmaSetting;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/OmaSettingInteger.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/OmaSettingInteger.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.OmaSetting;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/OmaSettingString.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/OmaSettingString.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.OmaSetting;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/OmaSettingStringXml.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/OmaSettingStringXml.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.OmaSetting;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/OnPremisesConditionalAccessSettings.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/OnPremisesConditionalAccessSettings.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Entity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/OnPremisesExtensionAttributes.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/OnPremisesExtensionAttributes.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/OnPremisesProvisioningError.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/OnPremisesProvisioningError.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/Onenote.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Onenote.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Notebook;
 import com.microsoft.graph.models.extensions.OnenoteOperation;
@@ -15,17 +14,11 @@ import com.microsoft.graph.models.extensions.OnenoteResource;
 import com.microsoft.graph.models.extensions.SectionGroup;
 import com.microsoft.graph.models.extensions.OnenoteSection;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.NotebookCollectionResponse;
 import com.microsoft.graph.requests.extensions.NotebookCollectionPage;
-import com.microsoft.graph.requests.extensions.OnenoteOperationCollectionResponse;
 import com.microsoft.graph.requests.extensions.OnenoteOperationCollectionPage;
-import com.microsoft.graph.requests.extensions.OnenotePageCollectionResponse;
 import com.microsoft.graph.requests.extensions.OnenotePageCollectionPage;
-import com.microsoft.graph.requests.extensions.OnenoteResourceCollectionResponse;
 import com.microsoft.graph.requests.extensions.OnenoteResourceCollectionPage;
-import com.microsoft.graph.requests.extensions.SectionGroupCollectionResponse;
 import com.microsoft.graph.requests.extensions.SectionGroupCollectionPage;
-import com.microsoft.graph.requests.extensions.OnenoteSectionCollectionResponse;
 import com.microsoft.graph.requests.extensions.OnenoteSectionCollectionPage;
 
 
@@ -130,99 +123,27 @@ public class Onenote extends Entity implements IJsonBackedObject {
 
 
         if (json.has("notebooks")) {
-            final NotebookCollectionResponse response = new NotebookCollectionResponse();
-            if (json.has("notebooks@odata.nextLink")) {
-                response.nextLink = json.get("notebooks@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("notebooks").toString(), JsonObject[].class);
-            final Notebook[] array = new Notebook[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), Notebook.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            notebooks = new NotebookCollectionPage(response, null);
+            notebooks = serializer.deserializeObject(json.get("notebooks").toString(), NotebookCollectionPage.class);
         }
 
         if (json.has("operations")) {
-            final OnenoteOperationCollectionResponse response = new OnenoteOperationCollectionResponse();
-            if (json.has("operations@odata.nextLink")) {
-                response.nextLink = json.get("operations@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("operations").toString(), JsonObject[].class);
-            final OnenoteOperation[] array = new OnenoteOperation[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), OnenoteOperation.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            operations = new OnenoteOperationCollectionPage(response, null);
+            operations = serializer.deserializeObject(json.get("operations").toString(), OnenoteOperationCollectionPage.class);
         }
 
         if (json.has("pages")) {
-            final OnenotePageCollectionResponse response = new OnenotePageCollectionResponse();
-            if (json.has("pages@odata.nextLink")) {
-                response.nextLink = json.get("pages@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("pages").toString(), JsonObject[].class);
-            final OnenotePage[] array = new OnenotePage[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), OnenotePage.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            pages = new OnenotePageCollectionPage(response, null);
+            pages = serializer.deserializeObject(json.get("pages").toString(), OnenotePageCollectionPage.class);
         }
 
         if (json.has("resources")) {
-            final OnenoteResourceCollectionResponse response = new OnenoteResourceCollectionResponse();
-            if (json.has("resources@odata.nextLink")) {
-                response.nextLink = json.get("resources@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("resources").toString(), JsonObject[].class);
-            final OnenoteResource[] array = new OnenoteResource[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), OnenoteResource.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            resources = new OnenoteResourceCollectionPage(response, null);
+            resources = serializer.deserializeObject(json.get("resources").toString(), OnenoteResourceCollectionPage.class);
         }
 
         if (json.has("sectionGroups")) {
-            final SectionGroupCollectionResponse response = new SectionGroupCollectionResponse();
-            if (json.has("sectionGroups@odata.nextLink")) {
-                response.nextLink = json.get("sectionGroups@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("sectionGroups").toString(), JsonObject[].class);
-            final SectionGroup[] array = new SectionGroup[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), SectionGroup.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            sectionGroups = new SectionGroupCollectionPage(response, null);
+            sectionGroups = serializer.deserializeObject(json.get("sectionGroups").toString(), SectionGroupCollectionPage.class);
         }
 
         if (json.has("sections")) {
-            final OnenoteSectionCollectionResponse response = new OnenoteSectionCollectionResponse();
-            if (json.has("sections@odata.nextLink")) {
-                response.nextLink = json.get("sections@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("sections").toString(), JsonObject[].class);
-            final OnenoteSection[] array = new OnenoteSection[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), OnenoteSection.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            sections = new OnenoteSectionCollectionPage(response, null);
+            sections = serializer.deserializeObject(json.get("sections").toString(), OnenoteSectionCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/OnenoteEntityBaseModel.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/OnenoteEntityBaseModel.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Entity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/OnenoteEntityHierarchyModel.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/OnenoteEntityHierarchyModel.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.IdentitySet;
 import com.microsoft.graph.models.extensions.OnenoteEntitySchemaObjectModel;

--- a/src/main/java/com/microsoft/graph/models/extensions/OnenoteEntitySchemaObjectModel.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/OnenoteEntitySchemaObjectModel.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.OnenoteEntityBaseModel;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/OnenoteOperation.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/OnenoteOperation.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.OnenoteOperationError;
 import com.microsoft.graph.models.extensions.Operation;

--- a/src/main/java/com/microsoft/graph/models/extensions/OnenoteOperationError.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/OnenoteOperationError.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/OnenotePage.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/OnenotePage.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.PageLinks;
 import com.microsoft.graph.models.extensions.Notebook;

--- a/src/main/java/com/microsoft/graph/models/extensions/OnenotePagePreview.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/OnenotePagePreview.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.OnenotePagePreviewLinks;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/OnenotePagePreviewLinks.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/OnenotePagePreviewLinks.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.ExternalLink;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/OnenotePatchContentCommand.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/OnenotePatchContentCommand.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.OnenotePatchActionType;
 import com.microsoft.graph.models.generated.OnenotePatchInsertPosition;

--- a/src/main/java/com/microsoft/graph/models/extensions/OnenoteResource.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/OnenoteResource.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.OnenoteEntityBaseModel;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/OnenoteSection.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/OnenoteSection.java
@@ -6,14 +6,12 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.SectionLinks;
 import com.microsoft.graph.models.extensions.OnenotePage;
 import com.microsoft.graph.models.extensions.Notebook;
 import com.microsoft.graph.models.extensions.SectionGroup;
 import com.microsoft.graph.models.extensions.OnenoteEntityHierarchyModel;
-import com.microsoft.graph.requests.extensions.OnenotePageCollectionResponse;
 import com.microsoft.graph.requests.extensions.OnenotePageCollectionPage;
 
 
@@ -118,19 +116,7 @@ public class OnenoteSection extends OnenoteEntityHierarchyModel implements IJson
 
 
         if (json.has("pages")) {
-            final OnenotePageCollectionResponse response = new OnenotePageCollectionResponse();
-            if (json.has("pages@odata.nextLink")) {
-                response.nextLink = json.get("pages@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("pages").toString(), JsonObject[].class);
-            final OnenotePage[] array = new OnenotePage[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), OnenotePage.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            pages = new OnenotePageCollectionPage(response, null);
+            pages = serializer.deserializeObject(json.get("pages").toString(), OnenotePageCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/OnlineMeeting.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/OnlineMeeting.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.AudioConferencing;
 import com.microsoft.graph.models.extensions.ChatInfo;

--- a/src/main/java/com/microsoft/graph/models/extensions/OnlineMeetingInfo.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/OnlineMeetingInfo.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Phone;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/OpenShift.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/OpenShift.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.OpenShiftItem;
 import com.microsoft.graph.models.extensions.ChangeTrackedEntity;

--- a/src/main/java/com/microsoft/graph/models/extensions/OpenShiftChangeRequest.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/OpenShiftChangeRequest.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.ScheduleChangeRequest;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/OpenShiftItem.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/OpenShiftItem.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.ShiftItem;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/OpenTypeExtension.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/OpenTypeExtension.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Extension;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/Operation.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Operation.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.OperationStatus;
 import com.microsoft.graph.models.extensions.Entity;

--- a/src/main/java/com/microsoft/graph/models/extensions/OperationError.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/OperationError.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/OptionalClaim.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/OptionalClaim.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/OptionalClaims.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/OptionalClaims.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.OptionalClaim;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/OrgContact.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/OrgContact.java
@@ -6,13 +6,11 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.PhysicalOfficeAddress;
 import com.microsoft.graph.models.extensions.OnPremisesProvisioningError;
 import com.microsoft.graph.models.extensions.Phone;
 import com.microsoft.graph.models.extensions.DirectoryObject;
-import com.microsoft.graph.requests.extensions.DirectoryObjectCollectionResponse;
 import com.microsoft.graph.requests.extensions.DirectoryObjectCollectionPage;
 
 
@@ -207,51 +205,15 @@ public class OrgContact extends DirectoryObject implements IJsonBackedObject {
 
 
         if (json.has("directReports")) {
-            final DirectoryObjectCollectionResponse response = new DirectoryObjectCollectionResponse();
-            if (json.has("directReports@odata.nextLink")) {
-                response.nextLink = json.get("directReports@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("directReports").toString(), JsonObject[].class);
-            final DirectoryObject[] array = new DirectoryObject[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DirectoryObject.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            directReports = new DirectoryObjectCollectionPage(response, null);
+            directReports = serializer.deserializeObject(json.get("directReports").toString(), DirectoryObjectCollectionPage.class);
         }
 
         if (json.has("memberOf")) {
-            final DirectoryObjectCollectionResponse response = new DirectoryObjectCollectionResponse();
-            if (json.has("memberOf@odata.nextLink")) {
-                response.nextLink = json.get("memberOf@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("memberOf").toString(), JsonObject[].class);
-            final DirectoryObject[] array = new DirectoryObject[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DirectoryObject.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            memberOf = new DirectoryObjectCollectionPage(response, null);
+            memberOf = serializer.deserializeObject(json.get("memberOf").toString(), DirectoryObjectCollectionPage.class);
         }
 
         if (json.has("transitiveMemberOf")) {
-            final DirectoryObjectCollectionResponse response = new DirectoryObjectCollectionResponse();
-            if (json.has("transitiveMemberOf@odata.nextLink")) {
-                response.nextLink = json.get("transitiveMemberOf@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("transitiveMemberOf").toString(), JsonObject[].class);
-            final DirectoryObject[] array = new DirectoryObject[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DirectoryObject.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            transitiveMemberOf = new DirectoryObjectCollectionPage(response, null);
+            transitiveMemberOf = serializer.deserializeObject(json.get("transitiveMemberOf").toString(), DirectoryObjectCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/Organization.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Organization.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.AssignedPlan;
 import com.microsoft.graph.models.extensions.PrivacyProfile;
@@ -16,9 +15,7 @@ import com.microsoft.graph.models.generated.MdmAuthority;
 import com.microsoft.graph.models.extensions.CertificateBasedAuthConfiguration;
 import com.microsoft.graph.models.extensions.Extension;
 import com.microsoft.graph.models.extensions.DirectoryObject;
-import com.microsoft.graph.requests.extensions.CertificateBasedAuthConfigurationCollectionResponse;
 import com.microsoft.graph.requests.extensions.CertificateBasedAuthConfigurationCollectionPage;
-import com.microsoft.graph.requests.extensions.ExtensionCollectionResponse;
 import com.microsoft.graph.requests.extensions.ExtensionCollectionPage;
 
 
@@ -265,35 +262,11 @@ public class Organization extends DirectoryObject implements IJsonBackedObject {
 
 
         if (json.has("certificateBasedAuthConfiguration")) {
-            final CertificateBasedAuthConfigurationCollectionResponse response = new CertificateBasedAuthConfigurationCollectionResponse();
-            if (json.has("certificateBasedAuthConfiguration@odata.nextLink")) {
-                response.nextLink = json.get("certificateBasedAuthConfiguration@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("certificateBasedAuthConfiguration").toString(), JsonObject[].class);
-            final CertificateBasedAuthConfiguration[] array = new CertificateBasedAuthConfiguration[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), CertificateBasedAuthConfiguration.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            certificateBasedAuthConfiguration = new CertificateBasedAuthConfigurationCollectionPage(response, null);
+            certificateBasedAuthConfiguration = serializer.deserializeObject(json.get("certificateBasedAuthConfiguration").toString(), CertificateBasedAuthConfigurationCollectionPage.class);
         }
 
         if (json.has("extensions")) {
-            final ExtensionCollectionResponse response = new ExtensionCollectionResponse();
-            if (json.has("extensions@odata.nextLink")) {
-                response.nextLink = json.get("extensions@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("extensions").toString(), JsonObject[].class);
-            final Extension[] array = new Extension[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), Extension.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            extensions = new ExtensionCollectionPage(response, null);
+            extensions = serializer.deserializeObject(json.get("extensions").toString(), ExtensionCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/OrganizerMeetingInfo.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/OrganizerMeetingInfo.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.IdentitySet;
 import com.microsoft.graph.models.extensions.MeetingInfo;

--- a/src/main/java/com/microsoft/graph/models/extensions/OutgoingCallOptions.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/OutgoingCallOptions.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.CallOptions;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/OutlookCategory.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/OutlookCategory.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.CategoryColor;
 import com.microsoft.graph.models.extensions.Entity;

--- a/src/main/java/com/microsoft/graph/models/extensions/OutlookGeoCoordinates.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/OutlookGeoCoordinates.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/OutlookItem.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/OutlookItem.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Entity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/OutlookUser.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/OutlookUser.java
@@ -6,11 +6,9 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.OutlookCategory;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.OutlookCategoryCollectionResponse;
 import com.microsoft.graph.requests.extensions.OutlookCategoryCollectionPage;
 
 
@@ -75,19 +73,7 @@ public class OutlookUser extends Entity implements IJsonBackedObject {
 
 
         if (json.has("masterCategories")) {
-            final OutlookCategoryCollectionResponse response = new OutlookCategoryCollectionResponse();
-            if (json.has("masterCategories@odata.nextLink")) {
-                response.nextLink = json.get("masterCategories@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("masterCategories").toString(), JsonObject[].class);
-            final OutlookCategory[] array = new OutlookCategory[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), OutlookCategory.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            masterCategories = new OutlookCategoryCollectionPage(response, null);
+            masterCategories = serializer.deserializeObject(json.get("masterCategories").toString(), OutlookCategoryCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/Package.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Package.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/PageLinks.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/PageLinks.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.ExternalLink;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ParentalControlSettings.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ParentalControlSettings.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/Participant.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Participant.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.ParticipantInfo;
 import com.microsoft.graph.models.extensions.MediaStream;

--- a/src/main/java/com/microsoft/graph/models/extensions/ParticipantInfo.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ParticipantInfo.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.EndpointType;
 import com.microsoft.graph.models.extensions.IdentitySet;

--- a/src/main/java/com/microsoft/graph/models/extensions/PasswordCredential.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/PasswordCredential.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/PasswordProfile.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/PasswordProfile.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/PatternedRecurrence.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/PatternedRecurrence.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.RecurrencePattern;
 import com.microsoft.graph.models.extensions.RecurrenceRange;

--- a/src/main/java/com/microsoft/graph/models/extensions/PendingContentUpdate.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/PendingContentUpdate.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/PendingOperations.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/PendingOperations.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.PendingContentUpdate;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/Permission.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Permission.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.IdentitySet;
 import com.microsoft.graph.models.extensions.ItemReference;

--- a/src/main/java/com/microsoft/graph/models/extensions/PermissionGrantConditionSet.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/PermissionGrantConditionSet.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.PermissionType;
 import com.microsoft.graph.models.extensions.Entity;

--- a/src/main/java/com/microsoft/graph/models/extensions/PermissionGrantPolicy.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/PermissionGrantPolicy.java
@@ -6,11 +6,9 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.PermissionGrantConditionSet;
 import com.microsoft.graph.models.extensions.PolicyBase;
-import com.microsoft.graph.requests.extensions.PermissionGrantConditionSetCollectionResponse;
 import com.microsoft.graph.requests.extensions.PermissionGrantConditionSetCollectionPage;
 
 
@@ -83,35 +81,11 @@ public class PermissionGrantPolicy extends PolicyBase implements IJsonBackedObje
 
 
         if (json.has("excludes")) {
-            final PermissionGrantConditionSetCollectionResponse response = new PermissionGrantConditionSetCollectionResponse();
-            if (json.has("excludes@odata.nextLink")) {
-                response.nextLink = json.get("excludes@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("excludes").toString(), JsonObject[].class);
-            final PermissionGrantConditionSet[] array = new PermissionGrantConditionSet[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), PermissionGrantConditionSet.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            excludes = new PermissionGrantConditionSetCollectionPage(response, null);
+            excludes = serializer.deserializeObject(json.get("excludes").toString(), PermissionGrantConditionSetCollectionPage.class);
         }
 
         if (json.has("includes")) {
-            final PermissionGrantConditionSetCollectionResponse response = new PermissionGrantConditionSetCollectionResponse();
-            if (json.has("includes@odata.nextLink")) {
-                response.nextLink = json.get("includes@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("includes").toString(), JsonObject[].class);
-            final PermissionGrantConditionSet[] array = new PermissionGrantConditionSet[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), PermissionGrantConditionSet.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            includes = new PermissionGrantConditionSetCollectionPage(response, null);
+            includes = serializer.deserializeObject(json.get("includes").toString(), PermissionGrantConditionSetCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/PermissionScope.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/PermissionScope.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/PersistentBrowserSessionControl.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/PersistentBrowserSessionControl.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.PersistentBrowserSessionMode;
 import com.microsoft.graph.models.extensions.ConditionalAccessSessionControl;

--- a/src/main/java/com/microsoft/graph/models/extensions/Person.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Person.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.PersonType;
 import com.microsoft.graph.models.extensions.Phone;

--- a/src/main/java/com/microsoft/graph/models/extensions/PersonOrGroupColumn.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/PersonOrGroupColumn.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/PersonType.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/PersonType.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/Phone.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Phone.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.PhoneType;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/Photo.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Photo.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/PhysicalAddress.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/PhysicalAddress.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/PhysicalOfficeAddress.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/PhysicalOfficeAddress.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/Place.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Place.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.PhysicalAddress;
 import com.microsoft.graph.models.extensions.OutlookGeoCoordinates;

--- a/src/main/java/com/microsoft/graph/models/extensions/Planner.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Planner.java
@@ -6,17 +6,13 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.PlannerBucket;
 import com.microsoft.graph.models.extensions.PlannerPlan;
 import com.microsoft.graph.models.extensions.PlannerTask;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.PlannerBucketCollectionResponse;
 import com.microsoft.graph.requests.extensions.PlannerBucketCollectionPage;
-import com.microsoft.graph.requests.extensions.PlannerPlanCollectionResponse;
 import com.microsoft.graph.requests.extensions.PlannerPlanCollectionPage;
-import com.microsoft.graph.requests.extensions.PlannerTaskCollectionResponse;
 import com.microsoft.graph.requests.extensions.PlannerTaskCollectionPage;
 
 
@@ -97,51 +93,15 @@ public class Planner extends Entity implements IJsonBackedObject {
 
 
         if (json.has("buckets")) {
-            final PlannerBucketCollectionResponse response = new PlannerBucketCollectionResponse();
-            if (json.has("buckets@odata.nextLink")) {
-                response.nextLink = json.get("buckets@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("buckets").toString(), JsonObject[].class);
-            final PlannerBucket[] array = new PlannerBucket[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), PlannerBucket.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            buckets = new PlannerBucketCollectionPage(response, null);
+            buckets = serializer.deserializeObject(json.get("buckets").toString(), PlannerBucketCollectionPage.class);
         }
 
         if (json.has("plans")) {
-            final PlannerPlanCollectionResponse response = new PlannerPlanCollectionResponse();
-            if (json.has("plans@odata.nextLink")) {
-                response.nextLink = json.get("plans@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("plans").toString(), JsonObject[].class);
-            final PlannerPlan[] array = new PlannerPlan[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), PlannerPlan.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            plans = new PlannerPlanCollectionPage(response, null);
+            plans = serializer.deserializeObject(json.get("plans").toString(), PlannerPlanCollectionPage.class);
         }
 
         if (json.has("tasks")) {
-            final PlannerTaskCollectionResponse response = new PlannerTaskCollectionResponse();
-            if (json.has("tasks@odata.nextLink")) {
-                response.nextLink = json.get("tasks@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("tasks").toString(), JsonObject[].class);
-            final PlannerTask[] array = new PlannerTask[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), PlannerTask.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            tasks = new PlannerTaskCollectionPage(response, null);
+            tasks = serializer.deserializeObject(json.get("tasks").toString(), PlannerTaskCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/PlannerAppliedCategories.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/PlannerAppliedCategories.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/PlannerAssignedToTaskBoardTaskFormat.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/PlannerAssignedToTaskBoardTaskFormat.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.PlannerOrderHintsByAssignee;
 import com.microsoft.graph.models.extensions.Entity;

--- a/src/main/java/com/microsoft/graph/models/extensions/PlannerAssignment.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/PlannerAssignment.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.IdentitySet;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/PlannerAssignments.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/PlannerAssignments.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.PlannerAssignment;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/PlannerBucket.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/PlannerBucket.java
@@ -6,11 +6,9 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.PlannerTask;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.PlannerTaskCollectionResponse;
 import com.microsoft.graph.requests.extensions.PlannerTaskCollectionPage;
 
 
@@ -99,19 +97,7 @@ public class PlannerBucket extends Entity implements IJsonBackedObject {
 
 
         if (json.has("tasks")) {
-            final PlannerTaskCollectionResponse response = new PlannerTaskCollectionResponse();
-            if (json.has("tasks@odata.nextLink")) {
-                response.nextLink = json.get("tasks@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("tasks").toString(), JsonObject[].class);
-            final PlannerTask[] array = new PlannerTask[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), PlannerTask.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            tasks = new PlannerTaskCollectionPage(response, null);
+            tasks = serializer.deserializeObject(json.get("tasks").toString(), PlannerTaskCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/PlannerBucketTaskBoardTaskFormat.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/PlannerBucketTaskBoardTaskFormat.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Entity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/PlannerCategoryDescriptions.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/PlannerCategoryDescriptions.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/PlannerChecklistItem.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/PlannerChecklistItem.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.IdentitySet;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/PlannerChecklistItems.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/PlannerChecklistItems.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.PlannerChecklistItem;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/PlannerExternalReference.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/PlannerExternalReference.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.IdentitySet;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/PlannerExternalReferences.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/PlannerExternalReferences.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/PlannerGroup.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/PlannerGroup.java
@@ -6,11 +6,9 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.PlannerPlan;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.PlannerPlanCollectionResponse;
 import com.microsoft.graph.requests.extensions.PlannerPlanCollectionPage;
 
 
@@ -75,19 +73,7 @@ public class PlannerGroup extends Entity implements IJsonBackedObject {
 
 
         if (json.has("plans")) {
-            final PlannerPlanCollectionResponse response = new PlannerPlanCollectionResponse();
-            if (json.has("plans@odata.nextLink")) {
-                response.nextLink = json.get("plans@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("plans").toString(), JsonObject[].class);
-            final PlannerPlan[] array = new PlannerPlan[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), PlannerPlan.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            plans = new PlannerPlanCollectionPage(response, null);
+            plans = serializer.deserializeObject(json.get("plans").toString(), PlannerPlanCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/PlannerOrderHintsByAssignee.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/PlannerOrderHintsByAssignee.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/PlannerPlan.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/PlannerPlan.java
@@ -6,16 +6,13 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.IdentitySet;
 import com.microsoft.graph.models.extensions.PlannerBucket;
 import com.microsoft.graph.models.extensions.PlannerPlanDetails;
 import com.microsoft.graph.models.extensions.PlannerTask;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.PlannerBucketCollectionResponse;
 import com.microsoft.graph.requests.extensions.PlannerBucketCollectionPage;
-import com.microsoft.graph.requests.extensions.PlannerTaskCollectionResponse;
 import com.microsoft.graph.requests.extensions.PlannerTaskCollectionPage;
 
 
@@ -128,35 +125,11 @@ public class PlannerPlan extends Entity implements IJsonBackedObject {
 
 
         if (json.has("buckets")) {
-            final PlannerBucketCollectionResponse response = new PlannerBucketCollectionResponse();
-            if (json.has("buckets@odata.nextLink")) {
-                response.nextLink = json.get("buckets@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("buckets").toString(), JsonObject[].class);
-            final PlannerBucket[] array = new PlannerBucket[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), PlannerBucket.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            buckets = new PlannerBucketCollectionPage(response, null);
+            buckets = serializer.deserializeObject(json.get("buckets").toString(), PlannerBucketCollectionPage.class);
         }
 
         if (json.has("tasks")) {
-            final PlannerTaskCollectionResponse response = new PlannerTaskCollectionResponse();
-            if (json.has("tasks@odata.nextLink")) {
-                response.nextLink = json.get("tasks@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("tasks").toString(), JsonObject[].class);
-            final PlannerTask[] array = new PlannerTask[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), PlannerTask.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            tasks = new PlannerTaskCollectionPage(response, null);
+            tasks = serializer.deserializeObject(json.get("tasks").toString(), PlannerTaskCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/PlannerPlanDetails.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/PlannerPlanDetails.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.PlannerCategoryDescriptions;
 import com.microsoft.graph.models.extensions.PlannerUserIds;

--- a/src/main/java/com/microsoft/graph/models/extensions/PlannerProgressTaskBoardTaskFormat.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/PlannerProgressTaskBoardTaskFormat.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Entity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/PlannerTask.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/PlannerTask.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.PlannerAppliedCategories;
 import com.microsoft.graph.models.extensions.PlannerAssignments;

--- a/src/main/java/com/microsoft/graph/models/extensions/PlannerTaskDetails.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/PlannerTaskDetails.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.PlannerChecklistItems;
 import com.microsoft.graph.models.generated.PlannerPreviewType;

--- a/src/main/java/com/microsoft/graph/models/extensions/PlannerUser.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/PlannerUser.java
@@ -6,14 +6,11 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.PlannerPlan;
 import com.microsoft.graph.models.extensions.PlannerTask;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.PlannerPlanCollectionResponse;
 import com.microsoft.graph.requests.extensions.PlannerPlanCollectionPage;
-import com.microsoft.graph.requests.extensions.PlannerTaskCollectionResponse;
 import com.microsoft.graph.requests.extensions.PlannerTaskCollectionPage;
 
 
@@ -86,35 +83,11 @@ public class PlannerUser extends Entity implements IJsonBackedObject {
 
 
         if (json.has("plans")) {
-            final PlannerPlanCollectionResponse response = new PlannerPlanCollectionResponse();
-            if (json.has("plans@odata.nextLink")) {
-                response.nextLink = json.get("plans@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("plans").toString(), JsonObject[].class);
-            final PlannerPlan[] array = new PlannerPlan[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), PlannerPlan.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            plans = new PlannerPlanCollectionPage(response, null);
+            plans = serializer.deserializeObject(json.get("plans").toString(), PlannerPlanCollectionPage.class);
         }
 
         if (json.has("tasks")) {
-            final PlannerTaskCollectionResponse response = new PlannerTaskCollectionResponse();
-            if (json.has("tasks@odata.nextLink")) {
-                response.nextLink = json.get("tasks@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("tasks").toString(), JsonObject[].class);
-            final PlannerTask[] array = new PlannerTask[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), PlannerTask.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            tasks = new PlannerTaskCollectionPage(response, null);
+            tasks = serializer.deserializeObject(json.get("tasks").toString(), PlannerTaskCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/PlannerUserIds.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/PlannerUserIds.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/PlayPromptOperation.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/PlayPromptOperation.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.CommsOperation;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/PolicyBase.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/PolicyBase.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.DirectoryObject;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/PolicyRoot.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/PolicyRoot.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.ActivityBasedTimeoutPolicy;
 import com.microsoft.graph.models.extensions.ClaimsMappingPolicy;
@@ -17,19 +16,12 @@ import com.microsoft.graph.models.extensions.TokenLifetimePolicy;
 import com.microsoft.graph.models.extensions.ConditionalAccessPolicy;
 import com.microsoft.graph.models.extensions.IdentitySecurityDefaultsEnforcementPolicy;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.ActivityBasedTimeoutPolicyCollectionResponse;
 import com.microsoft.graph.requests.extensions.ActivityBasedTimeoutPolicyCollectionPage;
-import com.microsoft.graph.requests.extensions.ClaimsMappingPolicyCollectionResponse;
 import com.microsoft.graph.requests.extensions.ClaimsMappingPolicyCollectionPage;
-import com.microsoft.graph.requests.extensions.HomeRealmDiscoveryPolicyCollectionResponse;
 import com.microsoft.graph.requests.extensions.HomeRealmDiscoveryPolicyCollectionPage;
-import com.microsoft.graph.requests.extensions.PermissionGrantPolicyCollectionResponse;
 import com.microsoft.graph.requests.extensions.PermissionGrantPolicyCollectionPage;
-import com.microsoft.graph.requests.extensions.TokenIssuancePolicyCollectionResponse;
 import com.microsoft.graph.requests.extensions.TokenIssuancePolicyCollectionPage;
-import com.microsoft.graph.requests.extensions.TokenLifetimePolicyCollectionResponse;
 import com.microsoft.graph.requests.extensions.TokenLifetimePolicyCollectionPage;
-import com.microsoft.graph.requests.extensions.ConditionalAccessPolicyCollectionResponse;
 import com.microsoft.graph.requests.extensions.ConditionalAccessPolicyCollectionPage;
 
 
@@ -150,115 +142,31 @@ public class PolicyRoot extends Entity implements IJsonBackedObject {
 
 
         if (json.has("activityBasedTimeoutPolicies")) {
-            final ActivityBasedTimeoutPolicyCollectionResponse response = new ActivityBasedTimeoutPolicyCollectionResponse();
-            if (json.has("activityBasedTimeoutPolicies@odata.nextLink")) {
-                response.nextLink = json.get("activityBasedTimeoutPolicies@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("activityBasedTimeoutPolicies").toString(), JsonObject[].class);
-            final ActivityBasedTimeoutPolicy[] array = new ActivityBasedTimeoutPolicy[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), ActivityBasedTimeoutPolicy.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            activityBasedTimeoutPolicies = new ActivityBasedTimeoutPolicyCollectionPage(response, null);
+            activityBasedTimeoutPolicies = serializer.deserializeObject(json.get("activityBasedTimeoutPolicies").toString(), ActivityBasedTimeoutPolicyCollectionPage.class);
         }
 
         if (json.has("claimsMappingPolicies")) {
-            final ClaimsMappingPolicyCollectionResponse response = new ClaimsMappingPolicyCollectionResponse();
-            if (json.has("claimsMappingPolicies@odata.nextLink")) {
-                response.nextLink = json.get("claimsMappingPolicies@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("claimsMappingPolicies").toString(), JsonObject[].class);
-            final ClaimsMappingPolicy[] array = new ClaimsMappingPolicy[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), ClaimsMappingPolicy.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            claimsMappingPolicies = new ClaimsMappingPolicyCollectionPage(response, null);
+            claimsMappingPolicies = serializer.deserializeObject(json.get("claimsMappingPolicies").toString(), ClaimsMappingPolicyCollectionPage.class);
         }
 
         if (json.has("homeRealmDiscoveryPolicies")) {
-            final HomeRealmDiscoveryPolicyCollectionResponse response = new HomeRealmDiscoveryPolicyCollectionResponse();
-            if (json.has("homeRealmDiscoveryPolicies@odata.nextLink")) {
-                response.nextLink = json.get("homeRealmDiscoveryPolicies@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("homeRealmDiscoveryPolicies").toString(), JsonObject[].class);
-            final HomeRealmDiscoveryPolicy[] array = new HomeRealmDiscoveryPolicy[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), HomeRealmDiscoveryPolicy.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            homeRealmDiscoveryPolicies = new HomeRealmDiscoveryPolicyCollectionPage(response, null);
+            homeRealmDiscoveryPolicies = serializer.deserializeObject(json.get("homeRealmDiscoveryPolicies").toString(), HomeRealmDiscoveryPolicyCollectionPage.class);
         }
 
         if (json.has("permissionGrantPolicies")) {
-            final PermissionGrantPolicyCollectionResponse response = new PermissionGrantPolicyCollectionResponse();
-            if (json.has("permissionGrantPolicies@odata.nextLink")) {
-                response.nextLink = json.get("permissionGrantPolicies@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("permissionGrantPolicies").toString(), JsonObject[].class);
-            final PermissionGrantPolicy[] array = new PermissionGrantPolicy[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), PermissionGrantPolicy.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            permissionGrantPolicies = new PermissionGrantPolicyCollectionPage(response, null);
+            permissionGrantPolicies = serializer.deserializeObject(json.get("permissionGrantPolicies").toString(), PermissionGrantPolicyCollectionPage.class);
         }
 
         if (json.has("tokenIssuancePolicies")) {
-            final TokenIssuancePolicyCollectionResponse response = new TokenIssuancePolicyCollectionResponse();
-            if (json.has("tokenIssuancePolicies@odata.nextLink")) {
-                response.nextLink = json.get("tokenIssuancePolicies@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("tokenIssuancePolicies").toString(), JsonObject[].class);
-            final TokenIssuancePolicy[] array = new TokenIssuancePolicy[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), TokenIssuancePolicy.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            tokenIssuancePolicies = new TokenIssuancePolicyCollectionPage(response, null);
+            tokenIssuancePolicies = serializer.deserializeObject(json.get("tokenIssuancePolicies").toString(), TokenIssuancePolicyCollectionPage.class);
         }
 
         if (json.has("tokenLifetimePolicies")) {
-            final TokenLifetimePolicyCollectionResponse response = new TokenLifetimePolicyCollectionResponse();
-            if (json.has("tokenLifetimePolicies@odata.nextLink")) {
-                response.nextLink = json.get("tokenLifetimePolicies@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("tokenLifetimePolicies").toString(), JsonObject[].class);
-            final TokenLifetimePolicy[] array = new TokenLifetimePolicy[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), TokenLifetimePolicy.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            tokenLifetimePolicies = new TokenLifetimePolicyCollectionPage(response, null);
+            tokenLifetimePolicies = serializer.deserializeObject(json.get("tokenLifetimePolicies").toString(), TokenLifetimePolicyCollectionPage.class);
         }
 
         if (json.has("conditionalAccessPolicies")) {
-            final ConditionalAccessPolicyCollectionResponse response = new ConditionalAccessPolicyCollectionResponse();
-            if (json.has("conditionalAccessPolicies@odata.nextLink")) {
-                response.nextLink = json.get("conditionalAccessPolicies@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("conditionalAccessPolicies").toString(), JsonObject[].class);
-            final ConditionalAccessPolicy[] array = new ConditionalAccessPolicy[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), ConditionalAccessPolicy.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            conditionalAccessPolicies = new ConditionalAccessPolicyCollectionPage(response, null);
+            conditionalAccessPolicies = serializer.deserializeObject(json.get("conditionalAccessPolicies").toString(), ConditionalAccessPolicyCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/Post.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Post.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.ItemBody;
 import com.microsoft.graph.models.extensions.Recipient;
@@ -16,13 +15,9 @@ import com.microsoft.graph.models.extensions.Post;
 import com.microsoft.graph.models.extensions.MultiValueLegacyExtendedProperty;
 import com.microsoft.graph.models.extensions.SingleValueLegacyExtendedProperty;
 import com.microsoft.graph.models.extensions.OutlookItem;
-import com.microsoft.graph.requests.extensions.AttachmentCollectionResponse;
 import com.microsoft.graph.requests.extensions.AttachmentCollectionPage;
-import com.microsoft.graph.requests.extensions.ExtensionCollectionResponse;
 import com.microsoft.graph.requests.extensions.ExtensionCollectionPage;
-import com.microsoft.graph.requests.extensions.MultiValueLegacyExtendedPropertyCollectionResponse;
 import com.microsoft.graph.requests.extensions.MultiValueLegacyExtendedPropertyCollectionPage;
-import com.microsoft.graph.requests.extensions.SingleValueLegacyExtendedPropertyCollectionResponse;
 import com.microsoft.graph.requests.extensions.SingleValueLegacyExtendedPropertyCollectionPage;
 
 
@@ -183,67 +178,19 @@ public class Post extends OutlookItem implements IJsonBackedObject {
 
 
         if (json.has("attachments")) {
-            final AttachmentCollectionResponse response = new AttachmentCollectionResponse();
-            if (json.has("attachments@odata.nextLink")) {
-                response.nextLink = json.get("attachments@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("attachments").toString(), JsonObject[].class);
-            final Attachment[] array = new Attachment[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), Attachment.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            attachments = new AttachmentCollectionPage(response, null);
+            attachments = serializer.deserializeObject(json.get("attachments").toString(), AttachmentCollectionPage.class);
         }
 
         if (json.has("extensions")) {
-            final ExtensionCollectionResponse response = new ExtensionCollectionResponse();
-            if (json.has("extensions@odata.nextLink")) {
-                response.nextLink = json.get("extensions@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("extensions").toString(), JsonObject[].class);
-            final Extension[] array = new Extension[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), Extension.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            extensions = new ExtensionCollectionPage(response, null);
+            extensions = serializer.deserializeObject(json.get("extensions").toString(), ExtensionCollectionPage.class);
         }
 
         if (json.has("multiValueExtendedProperties")) {
-            final MultiValueLegacyExtendedPropertyCollectionResponse response = new MultiValueLegacyExtendedPropertyCollectionResponse();
-            if (json.has("multiValueExtendedProperties@odata.nextLink")) {
-                response.nextLink = json.get("multiValueExtendedProperties@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("multiValueExtendedProperties").toString(), JsonObject[].class);
-            final MultiValueLegacyExtendedProperty[] array = new MultiValueLegacyExtendedProperty[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), MultiValueLegacyExtendedProperty.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            multiValueExtendedProperties = new MultiValueLegacyExtendedPropertyCollectionPage(response, null);
+            multiValueExtendedProperties = serializer.deserializeObject(json.get("multiValueExtendedProperties").toString(), MultiValueLegacyExtendedPropertyCollectionPage.class);
         }
 
         if (json.has("singleValueExtendedProperties")) {
-            final SingleValueLegacyExtendedPropertyCollectionResponse response = new SingleValueLegacyExtendedPropertyCollectionResponse();
-            if (json.has("singleValueExtendedProperties@odata.nextLink")) {
-                response.nextLink = json.get("singleValueExtendedProperties@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("singleValueExtendedProperties").toString(), JsonObject[].class);
-            final SingleValueLegacyExtendedProperty[] array = new SingleValueLegacyExtendedProperty[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), SingleValueLegacyExtendedProperty.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            singleValueExtendedProperties = new SingleValueLegacyExtendedPropertyCollectionPage(response, null);
+            singleValueExtendedProperties = serializer.deserializeObject(json.get("singleValueExtendedProperties").toString(), SingleValueLegacyExtendedPropertyCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/PreAuthorizedApplication.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/PreAuthorizedApplication.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/PrivacyProfile.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/PrivacyProfile.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/Process.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Process.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.FileHash;
 import com.microsoft.graph.models.generated.ProcessIntegrityLevel;

--- a/src/main/java/com/microsoft/graph/models/extensions/ProfilePhoto.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ProfilePhoto.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Entity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/Prompt.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Prompt.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ProvisionedPlan.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ProvisionedPlan.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ProxiedDomain.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ProxiedDomain.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/PublicClientApplication.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/PublicClientApplication.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/PublicError.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/PublicError.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.PublicErrorDetail;
 import com.microsoft.graph.models.extensions.PublicInnerError;

--- a/src/main/java/com/microsoft/graph/models/extensions/PublicErrorDetail.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/PublicErrorDetail.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/PublicInnerError.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/PublicInnerError.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.PublicErrorDetail;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/PublicationFacet.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/PublicationFacet.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/Quota.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Quota.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.StoragePlanInformation;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/RecentNotebook.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/RecentNotebook.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.RecentNotebookLinks;
 import com.microsoft.graph.models.generated.OnenoteSourceService;

--- a/src/main/java/com/microsoft/graph/models/extensions/RecentNotebookLinks.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/RecentNotebookLinks.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.ExternalLink;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/Recipient.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Recipient.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.EmailAddress;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/RecordOperation.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/RecordOperation.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.CommsOperation;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/RecordingInfo.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/RecordingInfo.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.IdentitySet;
 import com.microsoft.graph.models.generated.RecordingStatus;

--- a/src/main/java/com/microsoft/graph/models/extensions/RecurrencePattern.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/RecurrencePattern.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.DayOfWeek;
 import com.microsoft.graph.models.generated.WeekIndex;

--- a/src/main/java/com/microsoft/graph/models/extensions/RecurrenceRange.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/RecurrenceRange.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.RecurrenceRangeType;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ReferenceAttachment.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ReferenceAttachment.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Attachment;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/RegistryKeyState.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/RegistryKeyState.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.RegistryHive;
 import com.microsoft.graph.models.generated.RegistryOperation;

--- a/src/main/java/com/microsoft/graph/models/extensions/Reminder.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Reminder.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.DateTimeTimeZone;
 import com.microsoft.graph.models.extensions.Location;

--- a/src/main/java/com/microsoft/graph/models/extensions/RemoteAssistancePartner.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/RemoteAssistancePartner.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.RemoteAssistanceOnboardingStatus;
 import com.microsoft.graph.models.extensions.Entity;

--- a/src/main/java/com/microsoft/graph/models/extensions/RemoteItem.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/RemoteItem.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.IdentitySet;
 import com.microsoft.graph.models.extensions.File;

--- a/src/main/java/com/microsoft/graph/models/extensions/RemoteLockActionResult.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/RemoteLockActionResult.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.DeviceActionResult;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/Report.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Report.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ReportRoot.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ReportRoot.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Entity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/RequiredResourceAccess.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/RequiredResourceAccess.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.ResourceAccess;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ResetPasscodeActionResult.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ResetPasscodeActionResult.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.DeviceActionResult;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ResourceAccess.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ResourceAccess.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ResourceAction.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ResourceAction.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ResourceData.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ResourceData.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ResourceOperation.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ResourceOperation.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Entity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ResourceReference.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ResourceReference.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ResourceVisualization.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ResourceVisualization.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ResponseStatus.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ResponseStatus.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.ResponseType;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/RestrictedSignIn.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/RestrictedSignIn.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.SignIn;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ResultInfo.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ResultInfo.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/RgbColor.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/RgbColor.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/RoleAssignment.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/RoleAssignment.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.RoleDefinition;
 import com.microsoft.graph.models.extensions.Entity;

--- a/src/main/java/com/microsoft/graph/models/extensions/RoleDefinition.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/RoleDefinition.java
@@ -6,12 +6,10 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.RolePermission;
 import com.microsoft.graph.models.extensions.RoleAssignment;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.RoleAssignmentCollectionResponse;
 import com.microsoft.graph.requests.extensions.RoleAssignmentCollectionPage;
 
 
@@ -108,19 +106,7 @@ public class RoleDefinition extends Entity implements IJsonBackedObject {
 
 
         if (json.has("roleAssignments")) {
-            final RoleAssignmentCollectionResponse response = new RoleAssignmentCollectionResponse();
-            if (json.has("roleAssignments@odata.nextLink")) {
-                response.nextLink = json.get("roleAssignments@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("roleAssignments").toString(), JsonObject[].class);
-            final RoleAssignment[] array = new RoleAssignment[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), RoleAssignment.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            roleAssignments = new RoleAssignmentCollectionPage(response, null);
+            roleAssignments = serializer.deserializeObject(json.get("roleAssignments").toString(), RoleAssignmentCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/RolePermission.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/RolePermission.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.ResourceAction;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/Room.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Room.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.BookingType;
 import com.microsoft.graph.models.extensions.Place;

--- a/src/main/java/com/microsoft/graph/models/extensions/RoomList.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/RoomList.java
@@ -6,11 +6,9 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Room;
 import com.microsoft.graph.models.extensions.Place;
-import com.microsoft.graph.requests.extensions.RoomCollectionResponse;
 import com.microsoft.graph.requests.extensions.RoomCollectionPage;
 
 
@@ -83,19 +81,7 @@ public class RoomList extends Place implements IJsonBackedObject {
 
 
         if (json.has("rooms")) {
-            final RoomCollectionResponse response = new RoomCollectionResponse();
-            if (json.has("rooms@odata.nextLink")) {
-                response.nextLink = json.get("rooms@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("rooms").toString(), JsonObject[].class);
-            final Room[] array = new Room[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), Room.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            rooms = new RoomCollectionPage(response, null);
+            rooms = serializer.deserializeObject(json.get("rooms").toString(), RoomCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/Root.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Root.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/SamlSingleSignOnSettings.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/SamlSingleSignOnSettings.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/Schedule.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Schedule.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.OperationStatus;
 import com.microsoft.graph.models.extensions.OfferShiftRequest;
@@ -19,23 +18,14 @@ import com.microsoft.graph.models.extensions.TimeOffReason;
 import com.microsoft.graph.models.extensions.TimeOffRequest;
 import com.microsoft.graph.models.extensions.TimeOff;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.OfferShiftRequestCollectionResponse;
 import com.microsoft.graph.requests.extensions.OfferShiftRequestCollectionPage;
-import com.microsoft.graph.requests.extensions.OpenShiftChangeRequestCollectionResponse;
 import com.microsoft.graph.requests.extensions.OpenShiftChangeRequestCollectionPage;
-import com.microsoft.graph.requests.extensions.OpenShiftCollectionResponse;
 import com.microsoft.graph.requests.extensions.OpenShiftCollectionPage;
-import com.microsoft.graph.requests.extensions.SchedulingGroupCollectionResponse;
 import com.microsoft.graph.requests.extensions.SchedulingGroupCollectionPage;
-import com.microsoft.graph.requests.extensions.ShiftCollectionResponse;
 import com.microsoft.graph.requests.extensions.ShiftCollectionPage;
-import com.microsoft.graph.requests.extensions.SwapShiftsChangeRequestCollectionResponse;
 import com.microsoft.graph.requests.extensions.SwapShiftsChangeRequestCollectionPage;
-import com.microsoft.graph.requests.extensions.TimeOffReasonCollectionResponse;
 import com.microsoft.graph.requests.extensions.TimeOffReasonCollectionPage;
-import com.microsoft.graph.requests.extensions.TimeOffRequestCollectionResponse;
 import com.microsoft.graph.requests.extensions.TimeOffRequestCollectionPage;
-import com.microsoft.graph.requests.extensions.TimeOffCollectionResponse;
 import com.microsoft.graph.requests.extensions.TimeOffCollectionPage;
 
 
@@ -244,147 +234,39 @@ public class Schedule extends Entity implements IJsonBackedObject {
 
 
         if (json.has("offerShiftRequests")) {
-            final OfferShiftRequestCollectionResponse response = new OfferShiftRequestCollectionResponse();
-            if (json.has("offerShiftRequests@odata.nextLink")) {
-                response.nextLink = json.get("offerShiftRequests@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("offerShiftRequests").toString(), JsonObject[].class);
-            final OfferShiftRequest[] array = new OfferShiftRequest[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), OfferShiftRequest.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            offerShiftRequests = new OfferShiftRequestCollectionPage(response, null);
+            offerShiftRequests = serializer.deserializeObject(json.get("offerShiftRequests").toString(), OfferShiftRequestCollectionPage.class);
         }
 
         if (json.has("openShiftChangeRequests")) {
-            final OpenShiftChangeRequestCollectionResponse response = new OpenShiftChangeRequestCollectionResponse();
-            if (json.has("openShiftChangeRequests@odata.nextLink")) {
-                response.nextLink = json.get("openShiftChangeRequests@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("openShiftChangeRequests").toString(), JsonObject[].class);
-            final OpenShiftChangeRequest[] array = new OpenShiftChangeRequest[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), OpenShiftChangeRequest.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            openShiftChangeRequests = new OpenShiftChangeRequestCollectionPage(response, null);
+            openShiftChangeRequests = serializer.deserializeObject(json.get("openShiftChangeRequests").toString(), OpenShiftChangeRequestCollectionPage.class);
         }
 
         if (json.has("openShifts")) {
-            final OpenShiftCollectionResponse response = new OpenShiftCollectionResponse();
-            if (json.has("openShifts@odata.nextLink")) {
-                response.nextLink = json.get("openShifts@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("openShifts").toString(), JsonObject[].class);
-            final OpenShift[] array = new OpenShift[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), OpenShift.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            openShifts = new OpenShiftCollectionPage(response, null);
+            openShifts = serializer.deserializeObject(json.get("openShifts").toString(), OpenShiftCollectionPage.class);
         }
 
         if (json.has("schedulingGroups")) {
-            final SchedulingGroupCollectionResponse response = new SchedulingGroupCollectionResponse();
-            if (json.has("schedulingGroups@odata.nextLink")) {
-                response.nextLink = json.get("schedulingGroups@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("schedulingGroups").toString(), JsonObject[].class);
-            final SchedulingGroup[] array = new SchedulingGroup[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), SchedulingGroup.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            schedulingGroups = new SchedulingGroupCollectionPage(response, null);
+            schedulingGroups = serializer.deserializeObject(json.get("schedulingGroups").toString(), SchedulingGroupCollectionPage.class);
         }
 
         if (json.has("shifts")) {
-            final ShiftCollectionResponse response = new ShiftCollectionResponse();
-            if (json.has("shifts@odata.nextLink")) {
-                response.nextLink = json.get("shifts@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("shifts").toString(), JsonObject[].class);
-            final Shift[] array = new Shift[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), Shift.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            shifts = new ShiftCollectionPage(response, null);
+            shifts = serializer.deserializeObject(json.get("shifts").toString(), ShiftCollectionPage.class);
         }
 
         if (json.has("swapShiftsChangeRequests")) {
-            final SwapShiftsChangeRequestCollectionResponse response = new SwapShiftsChangeRequestCollectionResponse();
-            if (json.has("swapShiftsChangeRequests@odata.nextLink")) {
-                response.nextLink = json.get("swapShiftsChangeRequests@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("swapShiftsChangeRequests").toString(), JsonObject[].class);
-            final SwapShiftsChangeRequest[] array = new SwapShiftsChangeRequest[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), SwapShiftsChangeRequest.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            swapShiftsChangeRequests = new SwapShiftsChangeRequestCollectionPage(response, null);
+            swapShiftsChangeRequests = serializer.deserializeObject(json.get("swapShiftsChangeRequests").toString(), SwapShiftsChangeRequestCollectionPage.class);
         }
 
         if (json.has("timeOffReasons")) {
-            final TimeOffReasonCollectionResponse response = new TimeOffReasonCollectionResponse();
-            if (json.has("timeOffReasons@odata.nextLink")) {
-                response.nextLink = json.get("timeOffReasons@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("timeOffReasons").toString(), JsonObject[].class);
-            final TimeOffReason[] array = new TimeOffReason[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), TimeOffReason.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            timeOffReasons = new TimeOffReasonCollectionPage(response, null);
+            timeOffReasons = serializer.deserializeObject(json.get("timeOffReasons").toString(), TimeOffReasonCollectionPage.class);
         }
 
         if (json.has("timeOffRequests")) {
-            final TimeOffRequestCollectionResponse response = new TimeOffRequestCollectionResponse();
-            if (json.has("timeOffRequests@odata.nextLink")) {
-                response.nextLink = json.get("timeOffRequests@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("timeOffRequests").toString(), JsonObject[].class);
-            final TimeOffRequest[] array = new TimeOffRequest[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), TimeOffRequest.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            timeOffRequests = new TimeOffRequestCollectionPage(response, null);
+            timeOffRequests = serializer.deserializeObject(json.get("timeOffRequests").toString(), TimeOffRequestCollectionPage.class);
         }
 
         if (json.has("timesOff")) {
-            final TimeOffCollectionResponse response = new TimeOffCollectionResponse();
-            if (json.has("timesOff@odata.nextLink")) {
-                response.nextLink = json.get("timesOff@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("timesOff").toString(), JsonObject[].class);
-            final TimeOff[] array = new TimeOff[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), TimeOff.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            timesOff = new TimeOffCollectionPage(response, null);
+            timesOff = serializer.deserializeObject(json.get("timesOff").toString(), TimeOffCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/ScheduleChangeRequest.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ScheduleChangeRequest.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.ScheduleChangeRequestActor;
 import com.microsoft.graph.models.generated.ScheduleChangeState;

--- a/src/main/java/com/microsoft/graph/models/extensions/ScheduleEntity.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ScheduleEntity.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.ScheduleEntityTheme;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ScheduleInformation.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ScheduleInformation.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.FreeBusyError;
 import com.microsoft.graph.models.extensions.ScheduleItem;

--- a/src/main/java/com/microsoft/graph/models/extensions/ScheduleItem.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ScheduleItem.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.DateTimeTimeZone;
 import com.microsoft.graph.models.generated.FreeBusyStatus;

--- a/src/main/java/com/microsoft/graph/models/extensions/SchedulingGroup.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/SchedulingGroup.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.ChangeTrackedEntity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/SchemaExtension.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/SchemaExtension.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.ExtensionSchemaProperty;
 import com.microsoft.graph.models.extensions.Entity;

--- a/src/main/java/com/microsoft/graph/models/extensions/ScopedRoleMembership.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ScopedRoleMembership.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Identity;
 import com.microsoft.graph.models.extensions.Entity;

--- a/src/main/java/com/microsoft/graph/models/extensions/ScoredEmailAddress.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ScoredEmailAddress.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.SelectionLikelihoodInfo;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/SearchResult.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/SearchResult.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/SectionGroup.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/SectionGroup.java
@@ -6,15 +6,12 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Notebook;
 import com.microsoft.graph.models.extensions.SectionGroup;
 import com.microsoft.graph.models.extensions.OnenoteSection;
 import com.microsoft.graph.models.extensions.OnenoteEntityHierarchyModel;
-import com.microsoft.graph.requests.extensions.SectionGroupCollectionResponse;
 import com.microsoft.graph.requests.extensions.SectionGroupCollectionPage;
-import com.microsoft.graph.requests.extensions.OnenoteSectionCollectionResponse;
 import com.microsoft.graph.requests.extensions.OnenoteSectionCollectionPage;
 
 
@@ -119,35 +116,11 @@ public class SectionGroup extends OnenoteEntityHierarchyModel implements IJsonBa
 
 
         if (json.has("sectionGroups")) {
-            final SectionGroupCollectionResponse response = new SectionGroupCollectionResponse();
-            if (json.has("sectionGroups@odata.nextLink")) {
-                response.nextLink = json.get("sectionGroups@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("sectionGroups").toString(), JsonObject[].class);
-            final SectionGroup[] array = new SectionGroup[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), SectionGroup.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            sectionGroups = new SectionGroupCollectionPage(response, null);
+            sectionGroups = serializer.deserializeObject(json.get("sectionGroups").toString(), SectionGroupCollectionPage.class);
         }
 
         if (json.has("sections")) {
-            final OnenoteSectionCollectionResponse response = new OnenoteSectionCollectionResponse();
-            if (json.has("sections@odata.nextLink")) {
-                response.nextLink = json.get("sections@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("sections").toString(), JsonObject[].class);
-            final OnenoteSection[] array = new OnenoteSection[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), OnenoteSection.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            sections = new OnenoteSectionCollectionPage(response, null);
+            sections = serializer.deserializeObject(json.get("sections").toString(), OnenoteSectionCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/SectionLinks.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/SectionLinks.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.ExternalLink;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/SecureScore.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/SecureScore.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.AverageComparativeScore;
 import com.microsoft.graph.models.extensions.ControlScore;

--- a/src/main/java/com/microsoft/graph/models/extensions/SecureScoreControlProfile.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/SecureScoreControlProfile.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.ComplianceInformation;
 import com.microsoft.graph.models.extensions.SecureScoreControlStateUpdate;

--- a/src/main/java/com/microsoft/graph/models/extensions/SecureScoreControlStateUpdate.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/SecureScoreControlStateUpdate.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/Security.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Security.java
@@ -6,17 +6,13 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Alert;
 import com.microsoft.graph.models.extensions.SecureScoreControlProfile;
 import com.microsoft.graph.models.extensions.SecureScore;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.AlertCollectionResponse;
 import com.microsoft.graph.requests.extensions.AlertCollectionPage;
-import com.microsoft.graph.requests.extensions.SecureScoreControlProfileCollectionResponse;
 import com.microsoft.graph.requests.extensions.SecureScoreControlProfileCollectionPage;
-import com.microsoft.graph.requests.extensions.SecureScoreCollectionResponse;
 import com.microsoft.graph.requests.extensions.SecureScoreCollectionPage;
 
 
@@ -97,51 +93,15 @@ public class Security extends Entity implements IJsonBackedObject {
 
 
         if (json.has("alerts")) {
-            final AlertCollectionResponse response = new AlertCollectionResponse();
-            if (json.has("alerts@odata.nextLink")) {
-                response.nextLink = json.get("alerts@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("alerts").toString(), JsonObject[].class);
-            final Alert[] array = new Alert[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), Alert.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            alerts = new AlertCollectionPage(response, null);
+            alerts = serializer.deserializeObject(json.get("alerts").toString(), AlertCollectionPage.class);
         }
 
         if (json.has("secureScoreControlProfiles")) {
-            final SecureScoreControlProfileCollectionResponse response = new SecureScoreControlProfileCollectionResponse();
-            if (json.has("secureScoreControlProfiles@odata.nextLink")) {
-                response.nextLink = json.get("secureScoreControlProfiles@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("secureScoreControlProfiles").toString(), JsonObject[].class);
-            final SecureScoreControlProfile[] array = new SecureScoreControlProfile[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), SecureScoreControlProfile.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            secureScoreControlProfiles = new SecureScoreControlProfileCollectionPage(response, null);
+            secureScoreControlProfiles = serializer.deserializeObject(json.get("secureScoreControlProfiles").toString(), SecureScoreControlProfileCollectionPage.class);
         }
 
         if (json.has("secureScores")) {
-            final SecureScoreCollectionResponse response = new SecureScoreCollectionResponse();
-            if (json.has("secureScores@odata.nextLink")) {
-                response.nextLink = json.get("secureScores@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("secureScores").toString(), JsonObject[].class);
-            final SecureScore[] array = new SecureScore[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), SecureScore.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            secureScores = new SecureScoreCollectionPage(response, null);
+            secureScores = serializer.deserializeObject(json.get("secureScores").toString(), SecureScoreCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/SecurityResource.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/SecurityResource.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.SecurityResourceType;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/SecurityVendorInformation.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/SecurityVendorInformation.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ServiceHostedMediaConfig.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ServiceHostedMediaConfig.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.MediaInfo;
 import com.microsoft.graph.models.extensions.MediaConfig;

--- a/src/main/java/com/microsoft/graph/models/extensions/ServicePlanInfo.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ServicePlanInfo.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ServicePrincipal.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ServicePrincipal.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.AddIn;
 import com.microsoft.graph.models.extensions.AppRole;
@@ -23,21 +22,13 @@ import com.microsoft.graph.models.extensions.HomeRealmDiscoveryPolicy;
 import com.microsoft.graph.models.extensions.OAuth2PermissionGrant;
 import com.microsoft.graph.models.extensions.TokenIssuancePolicy;
 import com.microsoft.graph.models.extensions.TokenLifetimePolicy;
-import com.microsoft.graph.requests.extensions.AppRoleAssignmentCollectionResponse;
 import com.microsoft.graph.requests.extensions.AppRoleAssignmentCollectionPage;
-import com.microsoft.graph.requests.extensions.ClaimsMappingPolicyCollectionResponse;
 import com.microsoft.graph.requests.extensions.ClaimsMappingPolicyCollectionPage;
-import com.microsoft.graph.requests.extensions.DirectoryObjectCollectionResponse;
 import com.microsoft.graph.requests.extensions.DirectoryObjectCollectionPage;
-import com.microsoft.graph.requests.extensions.EndpointCollectionResponse;
 import com.microsoft.graph.requests.extensions.EndpointCollectionPage;
-import com.microsoft.graph.requests.extensions.HomeRealmDiscoveryPolicyCollectionResponse;
 import com.microsoft.graph.requests.extensions.HomeRealmDiscoveryPolicyCollectionPage;
-import com.microsoft.graph.requests.extensions.OAuth2PermissionGrantCollectionResponse;
 import com.microsoft.graph.requests.extensions.OAuth2PermissionGrantCollectionPage;
-import com.microsoft.graph.requests.extensions.TokenIssuancePolicyCollectionResponse;
 import com.microsoft.graph.requests.extensions.TokenIssuancePolicyCollectionPage;
-import com.microsoft.graph.requests.extensions.TokenLifetimePolicyCollectionResponse;
 import com.microsoft.graph.requests.extensions.TokenLifetimePolicyCollectionPage;
 
 
@@ -410,211 +401,55 @@ public class ServicePrincipal extends DirectoryObject implements IJsonBackedObje
 
 
         if (json.has("appRoleAssignedTo")) {
-            final AppRoleAssignmentCollectionResponse response = new AppRoleAssignmentCollectionResponse();
-            if (json.has("appRoleAssignedTo@odata.nextLink")) {
-                response.nextLink = json.get("appRoleAssignedTo@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("appRoleAssignedTo").toString(), JsonObject[].class);
-            final AppRoleAssignment[] array = new AppRoleAssignment[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), AppRoleAssignment.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            appRoleAssignedTo = new AppRoleAssignmentCollectionPage(response, null);
+            appRoleAssignedTo = serializer.deserializeObject(json.get("appRoleAssignedTo").toString(), AppRoleAssignmentCollectionPage.class);
         }
 
         if (json.has("appRoleAssignments")) {
-            final AppRoleAssignmentCollectionResponse response = new AppRoleAssignmentCollectionResponse();
-            if (json.has("appRoleAssignments@odata.nextLink")) {
-                response.nextLink = json.get("appRoleAssignments@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("appRoleAssignments").toString(), JsonObject[].class);
-            final AppRoleAssignment[] array = new AppRoleAssignment[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), AppRoleAssignment.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            appRoleAssignments = new AppRoleAssignmentCollectionPage(response, null);
+            appRoleAssignments = serializer.deserializeObject(json.get("appRoleAssignments").toString(), AppRoleAssignmentCollectionPage.class);
         }
 
         if (json.has("claimsMappingPolicies")) {
-            final ClaimsMappingPolicyCollectionResponse response = new ClaimsMappingPolicyCollectionResponse();
-            if (json.has("claimsMappingPolicies@odata.nextLink")) {
-                response.nextLink = json.get("claimsMappingPolicies@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("claimsMappingPolicies").toString(), JsonObject[].class);
-            final ClaimsMappingPolicy[] array = new ClaimsMappingPolicy[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), ClaimsMappingPolicy.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            claimsMappingPolicies = new ClaimsMappingPolicyCollectionPage(response, null);
+            claimsMappingPolicies = serializer.deserializeObject(json.get("claimsMappingPolicies").toString(), ClaimsMappingPolicyCollectionPage.class);
         }
 
         if (json.has("createdObjects")) {
-            final DirectoryObjectCollectionResponse response = new DirectoryObjectCollectionResponse();
-            if (json.has("createdObjects@odata.nextLink")) {
-                response.nextLink = json.get("createdObjects@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("createdObjects").toString(), JsonObject[].class);
-            final DirectoryObject[] array = new DirectoryObject[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DirectoryObject.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            createdObjects = new DirectoryObjectCollectionPage(response, null);
+            createdObjects = serializer.deserializeObject(json.get("createdObjects").toString(), DirectoryObjectCollectionPage.class);
         }
 
         if (json.has("endpoints")) {
-            final EndpointCollectionResponse response = new EndpointCollectionResponse();
-            if (json.has("endpoints@odata.nextLink")) {
-                response.nextLink = json.get("endpoints@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("endpoints").toString(), JsonObject[].class);
-            final Endpoint[] array = new Endpoint[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), Endpoint.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            endpoints = new EndpointCollectionPage(response, null);
+            endpoints = serializer.deserializeObject(json.get("endpoints").toString(), EndpointCollectionPage.class);
         }
 
         if (json.has("homeRealmDiscoveryPolicies")) {
-            final HomeRealmDiscoveryPolicyCollectionResponse response = new HomeRealmDiscoveryPolicyCollectionResponse();
-            if (json.has("homeRealmDiscoveryPolicies@odata.nextLink")) {
-                response.nextLink = json.get("homeRealmDiscoveryPolicies@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("homeRealmDiscoveryPolicies").toString(), JsonObject[].class);
-            final HomeRealmDiscoveryPolicy[] array = new HomeRealmDiscoveryPolicy[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), HomeRealmDiscoveryPolicy.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            homeRealmDiscoveryPolicies = new HomeRealmDiscoveryPolicyCollectionPage(response, null);
+            homeRealmDiscoveryPolicies = serializer.deserializeObject(json.get("homeRealmDiscoveryPolicies").toString(), HomeRealmDiscoveryPolicyCollectionPage.class);
         }
 
         if (json.has("memberOf")) {
-            final DirectoryObjectCollectionResponse response = new DirectoryObjectCollectionResponse();
-            if (json.has("memberOf@odata.nextLink")) {
-                response.nextLink = json.get("memberOf@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("memberOf").toString(), JsonObject[].class);
-            final DirectoryObject[] array = new DirectoryObject[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DirectoryObject.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            memberOf = new DirectoryObjectCollectionPage(response, null);
+            memberOf = serializer.deserializeObject(json.get("memberOf").toString(), DirectoryObjectCollectionPage.class);
         }
 
         if (json.has("oauth2PermissionGrants")) {
-            final OAuth2PermissionGrantCollectionResponse response = new OAuth2PermissionGrantCollectionResponse();
-            if (json.has("oauth2PermissionGrants@odata.nextLink")) {
-                response.nextLink = json.get("oauth2PermissionGrants@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("oauth2PermissionGrants").toString(), JsonObject[].class);
-            final OAuth2PermissionGrant[] array = new OAuth2PermissionGrant[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), OAuth2PermissionGrant.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            oauth2PermissionGrants = new OAuth2PermissionGrantCollectionPage(response, null);
+            oauth2PermissionGrants = serializer.deserializeObject(json.get("oauth2PermissionGrants").toString(), OAuth2PermissionGrantCollectionPage.class);
         }
 
         if (json.has("ownedObjects")) {
-            final DirectoryObjectCollectionResponse response = new DirectoryObjectCollectionResponse();
-            if (json.has("ownedObjects@odata.nextLink")) {
-                response.nextLink = json.get("ownedObjects@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("ownedObjects").toString(), JsonObject[].class);
-            final DirectoryObject[] array = new DirectoryObject[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DirectoryObject.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            ownedObjects = new DirectoryObjectCollectionPage(response, null);
+            ownedObjects = serializer.deserializeObject(json.get("ownedObjects").toString(), DirectoryObjectCollectionPage.class);
         }
 
         if (json.has("owners")) {
-            final DirectoryObjectCollectionResponse response = new DirectoryObjectCollectionResponse();
-            if (json.has("owners@odata.nextLink")) {
-                response.nextLink = json.get("owners@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("owners").toString(), JsonObject[].class);
-            final DirectoryObject[] array = new DirectoryObject[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DirectoryObject.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            owners = new DirectoryObjectCollectionPage(response, null);
+            owners = serializer.deserializeObject(json.get("owners").toString(), DirectoryObjectCollectionPage.class);
         }
 
         if (json.has("tokenIssuancePolicies")) {
-            final TokenIssuancePolicyCollectionResponse response = new TokenIssuancePolicyCollectionResponse();
-            if (json.has("tokenIssuancePolicies@odata.nextLink")) {
-                response.nextLink = json.get("tokenIssuancePolicies@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("tokenIssuancePolicies").toString(), JsonObject[].class);
-            final TokenIssuancePolicy[] array = new TokenIssuancePolicy[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), TokenIssuancePolicy.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            tokenIssuancePolicies = new TokenIssuancePolicyCollectionPage(response, null);
+            tokenIssuancePolicies = serializer.deserializeObject(json.get("tokenIssuancePolicies").toString(), TokenIssuancePolicyCollectionPage.class);
         }
 
         if (json.has("tokenLifetimePolicies")) {
-            final TokenLifetimePolicyCollectionResponse response = new TokenLifetimePolicyCollectionResponse();
-            if (json.has("tokenLifetimePolicies@odata.nextLink")) {
-                response.nextLink = json.get("tokenLifetimePolicies@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("tokenLifetimePolicies").toString(), JsonObject[].class);
-            final TokenLifetimePolicy[] array = new TokenLifetimePolicy[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), TokenLifetimePolicy.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            tokenLifetimePolicies = new TokenLifetimePolicyCollectionPage(response, null);
+            tokenLifetimePolicies = serializer.deserializeObject(json.get("tokenLifetimePolicies").toString(), TokenLifetimePolicyCollectionPage.class);
         }
 
         if (json.has("transitiveMemberOf")) {
-            final DirectoryObjectCollectionResponse response = new DirectoryObjectCollectionResponse();
-            if (json.has("transitiveMemberOf@odata.nextLink")) {
-                response.nextLink = json.get("transitiveMemberOf@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("transitiveMemberOf").toString(), JsonObject[].class);
-            final DirectoryObject[] array = new DirectoryObject[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DirectoryObject.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            transitiveMemberOf = new DirectoryObjectCollectionPage(response, null);
+            transitiveMemberOf = serializer.deserializeObject(json.get("transitiveMemberOf").toString(), DirectoryObjectCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/SettingSource.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/SettingSource.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/SettingStateDeviceSummary.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/SettingStateDeviceSummary.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Entity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/SettingTemplateValue.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/SettingTemplateValue.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/SettingValue.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/SettingValue.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/Shared.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Shared.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.IdentitySet;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/SharedDriveItem.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/SharedDriveItem.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.IdentitySet;
 import com.microsoft.graph.models.extensions.DriveItem;
@@ -15,7 +14,6 @@ import com.microsoft.graph.models.extensions.ListItem;
 import com.microsoft.graph.models.extensions.Permission;
 import com.microsoft.graph.models.extensions.Site;
 import com.microsoft.graph.models.extensions.BaseItem;
-import com.microsoft.graph.requests.extensions.DriveItemCollectionResponse;
 import com.microsoft.graph.requests.extensions.DriveItemCollectionPage;
 
 
@@ -136,19 +134,7 @@ public class SharedDriveItem extends BaseItem implements IJsonBackedObject {
 
 
         if (json.has("items")) {
-            final DriveItemCollectionResponse response = new DriveItemCollectionResponse();
-            if (json.has("items@odata.nextLink")) {
-                response.nextLink = json.get("items@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("items").toString(), JsonObject[].class);
-            final DriveItem[] array = new DriveItem[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DriveItem.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            items = new DriveItemCollectionPage(response, null);
+            items = serializer.deserializeObject(json.get("items").toString(), DriveItemCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/SharedInsight.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/SharedInsight.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.SharingDetail;
 import com.microsoft.graph.models.extensions.ResourceReference;

--- a/src/main/java/com/microsoft/graph/models/extensions/SharedPCAccountManagerPolicy.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/SharedPCAccountManagerPolicy.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.SharedPCAccountDeletionPolicyType;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/SharedPCConfiguration.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/SharedPCConfiguration.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.SharedPCAccountManagerPolicy;
 import com.microsoft.graph.models.generated.SharedPCAllowedAccountType;

--- a/src/main/java/com/microsoft/graph/models/extensions/SharepointIds.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/SharepointIds.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/SharingDetail.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/SharingDetail.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.InsightIdentity;
 import com.microsoft.graph.models.extensions.ResourceReference;

--- a/src/main/java/com/microsoft/graph/models/extensions/SharingInvitation.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/SharingInvitation.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.IdentitySet;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/SharingLink.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/SharingLink.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Identity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/Shift.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Shift.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.ShiftItem;
 import com.microsoft.graph.models.extensions.ChangeTrackedEntity;

--- a/src/main/java/com/microsoft/graph/models/extensions/ShiftActivity.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ShiftActivity.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.ScheduleEntityTheme;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ShiftAvailability.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ShiftAvailability.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.PatternedRecurrence;
 import com.microsoft.graph.models.extensions.TimeRange;

--- a/src/main/java/com/microsoft/graph/models/extensions/ShiftItem.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ShiftItem.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.ShiftActivity;
 import com.microsoft.graph.models.extensions.ScheduleEntity;

--- a/src/main/java/com/microsoft/graph/models/extensions/ShiftPreferences.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ShiftPreferences.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.ShiftAvailability;
 import com.microsoft.graph.models.extensions.ChangeTrackedEntity;

--- a/src/main/java/com/microsoft/graph/models/extensions/SignIn.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/SignIn.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.AppliedConditionalAccessPolicy;
 import com.microsoft.graph.models.generated.ConditionalAccessStatus;

--- a/src/main/java/com/microsoft/graph/models/extensions/SignInFrequencySessionControl.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/SignInFrequencySessionControl.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.SigninFrequencyType;
 import com.microsoft.graph.models.extensions.ConditionalAccessSessionControl;

--- a/src/main/java/com/microsoft/graph/models/extensions/SignInLocation.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/SignInLocation.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.GeoCoordinates;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/SignInStatus.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/SignInStatus.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/SingleValueLegacyExtendedProperty.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/SingleValueLegacyExtendedProperty.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Entity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/Site.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Site.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.PublicError;
 import com.microsoft.graph.models.extensions.Root;
@@ -20,17 +19,11 @@ import com.microsoft.graph.models.extensions.BaseItem;
 import com.microsoft.graph.models.extensions.List;
 import com.microsoft.graph.models.extensions.Site;
 import com.microsoft.graph.models.extensions.Onenote;
-import com.microsoft.graph.requests.extensions.ColumnDefinitionCollectionResponse;
 import com.microsoft.graph.requests.extensions.ColumnDefinitionCollectionPage;
-import com.microsoft.graph.requests.extensions.ContentTypeCollectionResponse;
 import com.microsoft.graph.requests.extensions.ContentTypeCollectionPage;
-import com.microsoft.graph.requests.extensions.DriveCollectionResponse;
 import com.microsoft.graph.requests.extensions.DriveCollectionPage;
-import com.microsoft.graph.requests.extensions.BaseItemCollectionResponse;
 import com.microsoft.graph.requests.extensions.BaseItemCollectionPage;
-import com.microsoft.graph.requests.extensions.ListCollectionResponse;
 import com.microsoft.graph.requests.extensions.ListCollectionPage;
-import com.microsoft.graph.requests.extensions.SiteCollectionResponse;
 import com.microsoft.graph.requests.extensions.SiteCollectionPage;
 
 
@@ -199,99 +192,27 @@ public class Site extends BaseItem implements IJsonBackedObject {
 
 
         if (json.has("columns")) {
-            final ColumnDefinitionCollectionResponse response = new ColumnDefinitionCollectionResponse();
-            if (json.has("columns@odata.nextLink")) {
-                response.nextLink = json.get("columns@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("columns").toString(), JsonObject[].class);
-            final ColumnDefinition[] array = new ColumnDefinition[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), ColumnDefinition.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            columns = new ColumnDefinitionCollectionPage(response, null);
+            columns = serializer.deserializeObject(json.get("columns").toString(), ColumnDefinitionCollectionPage.class);
         }
 
         if (json.has("contentTypes")) {
-            final ContentTypeCollectionResponse response = new ContentTypeCollectionResponse();
-            if (json.has("contentTypes@odata.nextLink")) {
-                response.nextLink = json.get("contentTypes@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("contentTypes").toString(), JsonObject[].class);
-            final ContentType[] array = new ContentType[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), ContentType.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            contentTypes = new ContentTypeCollectionPage(response, null);
+            contentTypes = serializer.deserializeObject(json.get("contentTypes").toString(), ContentTypeCollectionPage.class);
         }
 
         if (json.has("drives")) {
-            final DriveCollectionResponse response = new DriveCollectionResponse();
-            if (json.has("drives@odata.nextLink")) {
-                response.nextLink = json.get("drives@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("drives").toString(), JsonObject[].class);
-            final Drive[] array = new Drive[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), Drive.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            drives = new DriveCollectionPage(response, null);
+            drives = serializer.deserializeObject(json.get("drives").toString(), DriveCollectionPage.class);
         }
 
         if (json.has("items")) {
-            final BaseItemCollectionResponse response = new BaseItemCollectionResponse();
-            if (json.has("items@odata.nextLink")) {
-                response.nextLink = json.get("items@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("items").toString(), JsonObject[].class);
-            final BaseItem[] array = new BaseItem[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), BaseItem.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            items = new BaseItemCollectionPage(response, null);
+            items = serializer.deserializeObject(json.get("items").toString(), BaseItemCollectionPage.class);
         }
 
         if (json.has("lists")) {
-            final ListCollectionResponse response = new ListCollectionResponse();
-            if (json.has("lists@odata.nextLink")) {
-                response.nextLink = json.get("lists@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("lists").toString(), JsonObject[].class);
-            final List[] array = new List[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), List.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            lists = new ListCollectionPage(response, null);
+            lists = serializer.deserializeObject(json.get("lists").toString(), ListCollectionPage.class);
         }
 
         if (json.has("sites")) {
-            final SiteCollectionResponse response = new SiteCollectionResponse();
-            if (json.has("sites@odata.nextLink")) {
-                response.nextLink = json.get("sites@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("sites").toString(), JsonObject[].class);
-            final Site[] array = new Site[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), Site.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            sites = new SiteCollectionPage(response, null);
+            sites = serializer.deserializeObject(json.get("sites").toString(), SiteCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/SiteCollection.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/SiteCollection.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Root;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/SizeRange.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/SizeRange.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/SoftwareUpdateStatusSummary.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/SoftwareUpdateStatusSummary.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Entity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/SpecialFolder.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/SpecialFolder.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/StandardTimeZoneOffset.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/StandardTimeZoneOffset.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.DayOfWeek;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/StoragePlanInformation.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/StoragePlanInformation.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/StsPolicy.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/StsPolicy.java
@@ -6,11 +6,9 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.DirectoryObject;
 import com.microsoft.graph.models.extensions.PolicyBase;
-import com.microsoft.graph.requests.extensions.DirectoryObjectCollectionResponse;
 import com.microsoft.graph.requests.extensions.DirectoryObjectCollectionPage;
 
 
@@ -89,19 +87,7 @@ public class StsPolicy extends PolicyBase implements IJsonBackedObject {
 
 
         if (json.has("appliesTo")) {
-            final DirectoryObjectCollectionResponse response = new DirectoryObjectCollectionResponse();
-            if (json.has("appliesTo@odata.nextLink")) {
-                response.nextLink = json.get("appliesTo@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("appliesTo").toString(), JsonObject[].class);
-            final DirectoryObject[] array = new DirectoryObject[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DirectoryObject.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            appliesTo = new DirectoryObjectCollectionPage(response, null);
+            appliesTo = serializer.deserializeObject(json.get("appliesTo").toString(), DirectoryObjectCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/SubscribeToToneOperation.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/SubscribeToToneOperation.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.CommsOperation;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/SubscribedSku.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/SubscribedSku.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.LicenseUnitsDetail;
 import com.microsoft.graph.models.extensions.ServicePlanInfo;

--- a/src/main/java/com/microsoft/graph/models/extensions/Subscription.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Subscription.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Entity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/SwapShiftsChangeRequest.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/SwapShiftsChangeRequest.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.OfferShiftRequest;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/SystemFacet.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/SystemFacet.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/TargetResource.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/TargetResource.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.GroupType;
 import com.microsoft.graph.models.extensions.ModifiedProperty;

--- a/src/main/java/com/microsoft/graph/models/extensions/TargetedManagedAppConfiguration.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/TargetedManagedAppConfiguration.java
@@ -6,15 +6,12 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.ManagedMobileApp;
 import com.microsoft.graph.models.extensions.TargetedManagedAppPolicyAssignment;
 import com.microsoft.graph.models.extensions.ManagedAppPolicyDeploymentSummary;
 import com.microsoft.graph.models.extensions.ManagedAppConfiguration;
-import com.microsoft.graph.requests.extensions.ManagedMobileAppCollectionResponse;
 import com.microsoft.graph.requests.extensions.ManagedMobileAppCollectionPage;
-import com.microsoft.graph.requests.extensions.TargetedManagedAppPolicyAssignmentCollectionResponse;
 import com.microsoft.graph.requests.extensions.TargetedManagedAppPolicyAssignmentCollectionPage;
 
 
@@ -111,35 +108,11 @@ public class TargetedManagedAppConfiguration extends ManagedAppConfiguration imp
 
 
         if (json.has("apps")) {
-            final ManagedMobileAppCollectionResponse response = new ManagedMobileAppCollectionResponse();
-            if (json.has("apps@odata.nextLink")) {
-                response.nextLink = json.get("apps@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("apps").toString(), JsonObject[].class);
-            final ManagedMobileApp[] array = new ManagedMobileApp[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), ManagedMobileApp.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            apps = new ManagedMobileAppCollectionPage(response, null);
+            apps = serializer.deserializeObject(json.get("apps").toString(), ManagedMobileAppCollectionPage.class);
         }
 
         if (json.has("assignments")) {
-            final TargetedManagedAppPolicyAssignmentCollectionResponse response = new TargetedManagedAppPolicyAssignmentCollectionResponse();
-            if (json.has("assignments@odata.nextLink")) {
-                response.nextLink = json.get("assignments@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("assignments").toString(), JsonObject[].class);
-            final TargetedManagedAppPolicyAssignment[] array = new TargetedManagedAppPolicyAssignment[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), TargetedManagedAppPolicyAssignment.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            assignments = new TargetedManagedAppPolicyAssignmentCollectionPage(response, null);
+            assignments = serializer.deserializeObject(json.get("assignments").toString(), TargetedManagedAppPolicyAssignmentCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/TargetedManagedAppPolicyAssignment.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/TargetedManagedAppPolicyAssignment.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.DeviceAndAppManagementAssignmentTarget;
 import com.microsoft.graph.models.extensions.Entity;

--- a/src/main/java/com/microsoft/graph/models/extensions/TargetedManagedAppProtection.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/TargetedManagedAppProtection.java
@@ -6,11 +6,9 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.TargetedManagedAppPolicyAssignment;
 import com.microsoft.graph.models.extensions.ManagedAppProtection;
-import com.microsoft.graph.requests.extensions.TargetedManagedAppPolicyAssignmentCollectionResponse;
 import com.microsoft.graph.requests.extensions.TargetedManagedAppPolicyAssignmentCollectionPage;
 
 
@@ -83,19 +81,7 @@ public class TargetedManagedAppProtection extends ManagedAppProtection implement
 
 
         if (json.has("assignments")) {
-            final TargetedManagedAppPolicyAssignmentCollectionResponse response = new TargetedManagedAppPolicyAssignmentCollectionResponse();
-            if (json.has("assignments@odata.nextLink")) {
-                response.nextLink = json.get("assignments@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("assignments").toString(), JsonObject[].class);
-            final TargetedManagedAppPolicyAssignment[] array = new TargetedManagedAppPolicyAssignment[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), TargetedManagedAppPolicyAssignment.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            assignments = new TargetedManagedAppPolicyAssignmentCollectionPage(response, null);
+            assignments = serializer.deserializeObject(json.get("assignments").toString(), TargetedManagedAppPolicyAssignmentCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/Team.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Team.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.TeamFunSettings;
 import com.microsoft.graph.models.extensions.TeamGuestSettings;
@@ -22,13 +21,9 @@ import com.microsoft.graph.models.extensions.ConversationMember;
 import com.microsoft.graph.models.extensions.TeamsAsyncOperation;
 import com.microsoft.graph.models.extensions.TeamsTemplate;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.ChannelCollectionResponse;
 import com.microsoft.graph.requests.extensions.ChannelCollectionPage;
-import com.microsoft.graph.requests.extensions.TeamsAppInstallationCollectionResponse;
 import com.microsoft.graph.requests.extensions.TeamsAppInstallationCollectionPage;
-import com.microsoft.graph.requests.extensions.ConversationMemberCollectionResponse;
 import com.microsoft.graph.requests.extensions.ConversationMemberCollectionPage;
-import com.microsoft.graph.requests.extensions.TeamsAsyncOperationCollectionResponse;
 import com.microsoft.graph.requests.extensions.TeamsAsyncOperationCollectionPage;
 
 
@@ -245,67 +240,19 @@ public class Team extends Entity implements IJsonBackedObject {
 
 
         if (json.has("channels")) {
-            final ChannelCollectionResponse response = new ChannelCollectionResponse();
-            if (json.has("channels@odata.nextLink")) {
-                response.nextLink = json.get("channels@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("channels").toString(), JsonObject[].class);
-            final Channel[] array = new Channel[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), Channel.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            channels = new ChannelCollectionPage(response, null);
+            channels = serializer.deserializeObject(json.get("channels").toString(), ChannelCollectionPage.class);
         }
 
         if (json.has("installedApps")) {
-            final TeamsAppInstallationCollectionResponse response = new TeamsAppInstallationCollectionResponse();
-            if (json.has("installedApps@odata.nextLink")) {
-                response.nextLink = json.get("installedApps@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("installedApps").toString(), JsonObject[].class);
-            final TeamsAppInstallation[] array = new TeamsAppInstallation[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), TeamsAppInstallation.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            installedApps = new TeamsAppInstallationCollectionPage(response, null);
+            installedApps = serializer.deserializeObject(json.get("installedApps").toString(), TeamsAppInstallationCollectionPage.class);
         }
 
         if (json.has("members")) {
-            final ConversationMemberCollectionResponse response = new ConversationMemberCollectionResponse();
-            if (json.has("members@odata.nextLink")) {
-                response.nextLink = json.get("members@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("members").toString(), JsonObject[].class);
-            final ConversationMember[] array = new ConversationMember[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), ConversationMember.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            members = new ConversationMemberCollectionPage(response, null);
+            members = serializer.deserializeObject(json.get("members").toString(), ConversationMemberCollectionPage.class);
         }
 
         if (json.has("operations")) {
-            final TeamsAsyncOperationCollectionResponse response = new TeamsAsyncOperationCollectionResponse();
-            if (json.has("operations@odata.nextLink")) {
-                response.nextLink = json.get("operations@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("operations").toString(), JsonObject[].class);
-            final TeamsAsyncOperation[] array = new TeamsAsyncOperation[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), TeamsAsyncOperation.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            operations = new TeamsAsyncOperationCollectionPage(response, null);
+            operations = serializer.deserializeObject(json.get("operations").toString(), TeamsAsyncOperationCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/TeamClassSettings.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/TeamClassSettings.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/TeamFunSettings.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/TeamFunSettings.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.GiphyRatingType;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/TeamGuestSettings.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/TeamGuestSettings.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/TeamMemberSettings.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/TeamMemberSettings.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/TeamMessagingSettings.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/TeamMessagingSettings.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/TeamsApp.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/TeamsApp.java
@@ -6,12 +6,10 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.TeamsAppDistributionMethod;
 import com.microsoft.graph.models.extensions.TeamsAppDefinition;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.TeamsAppDefinitionCollectionResponse;
 import com.microsoft.graph.requests.extensions.TeamsAppDefinitionCollectionPage;
 
 
@@ -100,19 +98,7 @@ public class TeamsApp extends Entity implements IJsonBackedObject {
 
 
         if (json.has("appDefinitions")) {
-            final TeamsAppDefinitionCollectionResponse response = new TeamsAppDefinitionCollectionResponse();
-            if (json.has("appDefinitions@odata.nextLink")) {
-                response.nextLink = json.get("appDefinitions@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("appDefinitions").toString(), JsonObject[].class);
-            final TeamsAppDefinition[] array = new TeamsAppDefinition[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), TeamsAppDefinition.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            appDefinitions = new TeamsAppDefinitionCollectionPage(response, null);
+            appDefinitions = serializer.deserializeObject(json.get("appDefinitions").toString(), TeamsAppDefinitionCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/TeamsAppDefinition.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/TeamsAppDefinition.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Entity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/TeamsAppInstallation.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/TeamsAppInstallation.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.TeamsApp;
 import com.microsoft.graph.models.extensions.TeamsAppDefinition;

--- a/src/main/java/com/microsoft/graph/models/extensions/TeamsAsyncOperation.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/TeamsAsyncOperation.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.OperationError;
 import com.microsoft.graph.models.generated.TeamsAsyncOperationType;

--- a/src/main/java/com/microsoft/graph/models/extensions/TeamsTab.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/TeamsTab.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.TeamsTabConfiguration;
 import com.microsoft.graph.models.extensions.TeamsApp;

--- a/src/main/java/com/microsoft/graph/models/extensions/TeamsTabConfiguration.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/TeamsTabConfiguration.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/TeamsTemplate.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/TeamsTemplate.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Entity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/Teamwork.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Teamwork.java
@@ -6,11 +6,9 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.WorkforceIntegration;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.WorkforceIntegrationCollectionResponse;
 import com.microsoft.graph.requests.extensions.WorkforceIntegrationCollectionPage;
 
 
@@ -75,19 +73,7 @@ public class Teamwork extends Entity implements IJsonBackedObject {
 
 
         if (json.has("workforceIntegrations")) {
-            final WorkforceIntegrationCollectionResponse response = new WorkforceIntegrationCollectionResponse();
-            if (json.has("workforceIntegrations@odata.nextLink")) {
-                response.nextLink = json.get("workforceIntegrations@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("workforceIntegrations").toString(), JsonObject[].class);
-            final WorkforceIntegration[] array = new WorkforceIntegration[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), WorkforceIntegration.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            workforceIntegrations = new WorkforceIntegrationCollectionPage(response, null);
+            workforceIntegrations = serializer.deserializeObject(json.get("workforceIntegrations").toString(), WorkforceIntegrationCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/TelecomExpenseManagementPartner.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/TelecomExpenseManagementPartner.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Entity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/TeleconferenceDeviceAudioQuality.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/TeleconferenceDeviceAudioQuality.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.TeleconferenceDeviceMediaQuality;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/TeleconferenceDeviceMediaQuality.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/TeleconferenceDeviceMediaQuality.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/TeleconferenceDeviceQuality.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/TeleconferenceDeviceQuality.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.TeleconferenceDeviceMediaQuality;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/TeleconferenceDeviceScreenSharingQuality.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/TeleconferenceDeviceScreenSharingQuality.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.TeleconferenceDeviceVideoQuality;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/TeleconferenceDeviceVideoQuality.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/TeleconferenceDeviceVideoQuality.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.TeleconferenceDeviceMediaQuality;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/TermsAndConditions.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/TermsAndConditions.java
@@ -6,14 +6,11 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.TermsAndConditionsAcceptanceStatus;
 import com.microsoft.graph.models.extensions.TermsAndConditionsAssignment;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.TermsAndConditionsAcceptanceStatusCollectionResponse;
 import com.microsoft.graph.requests.extensions.TermsAndConditionsAcceptanceStatusCollectionPage;
-import com.microsoft.graph.requests.extensions.TermsAndConditionsAssignmentCollectionResponse;
 import com.microsoft.graph.requests.extensions.TermsAndConditionsAssignmentCollectionPage;
 
 
@@ -150,35 +147,11 @@ public class TermsAndConditions extends Entity implements IJsonBackedObject {
 
 
         if (json.has("acceptanceStatuses")) {
-            final TermsAndConditionsAcceptanceStatusCollectionResponse response = new TermsAndConditionsAcceptanceStatusCollectionResponse();
-            if (json.has("acceptanceStatuses@odata.nextLink")) {
-                response.nextLink = json.get("acceptanceStatuses@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("acceptanceStatuses").toString(), JsonObject[].class);
-            final TermsAndConditionsAcceptanceStatus[] array = new TermsAndConditionsAcceptanceStatus[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), TermsAndConditionsAcceptanceStatus.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            acceptanceStatuses = new TermsAndConditionsAcceptanceStatusCollectionPage(response, null);
+            acceptanceStatuses = serializer.deserializeObject(json.get("acceptanceStatuses").toString(), TermsAndConditionsAcceptanceStatusCollectionPage.class);
         }
 
         if (json.has("assignments")) {
-            final TermsAndConditionsAssignmentCollectionResponse response = new TermsAndConditionsAssignmentCollectionResponse();
-            if (json.has("assignments@odata.nextLink")) {
-                response.nextLink = json.get("assignments@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("assignments").toString(), JsonObject[].class);
-            final TermsAndConditionsAssignment[] array = new TermsAndConditionsAssignment[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), TermsAndConditionsAssignment.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            assignments = new TermsAndConditionsAssignmentCollectionPage(response, null);
+            assignments = serializer.deserializeObject(json.get("assignments").toString(), TermsAndConditionsAssignmentCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/TermsAndConditionsAcceptanceStatus.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/TermsAndConditionsAcceptanceStatus.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.TermsAndConditions;
 import com.microsoft.graph.models.extensions.Entity;

--- a/src/main/java/com/microsoft/graph/models/extensions/TermsAndConditionsAssignment.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/TermsAndConditionsAssignment.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.DeviceAndAppManagementAssignmentTarget;
 import com.microsoft.graph.models.extensions.Entity;

--- a/src/main/java/com/microsoft/graph/models/extensions/TextColumn.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/TextColumn.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ThreatAssessmentRequest.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ThreatAssessmentRequest.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.ThreatCategory;
 import com.microsoft.graph.models.generated.ThreatAssessmentContentType;
@@ -16,7 +15,6 @@ import com.microsoft.graph.models.generated.ThreatAssessmentRequestSource;
 import com.microsoft.graph.models.generated.ThreatAssessmentStatus;
 import com.microsoft.graph.models.extensions.ThreatAssessmentResult;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.ThreatAssessmentResultCollectionResponse;
 import com.microsoft.graph.requests.extensions.ThreatAssessmentResultCollectionPage;
 
 
@@ -137,19 +135,7 @@ public class ThreatAssessmentRequest extends Entity implements IJsonBackedObject
 
 
         if (json.has("results")) {
-            final ThreatAssessmentResultCollectionResponse response = new ThreatAssessmentResultCollectionResponse();
-            if (json.has("results@odata.nextLink")) {
-                response.nextLink = json.get("results@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("results").toString(), JsonObject[].class);
-            final ThreatAssessmentResult[] array = new ThreatAssessmentResult[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), ThreatAssessmentResult.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            results = new ThreatAssessmentResultCollectionPage(response, null);
+            results = serializer.deserializeObject(json.get("results").toString(), ThreatAssessmentResultCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/ThreatAssessmentResult.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ThreatAssessmentResult.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.ThreatAssessmentResultType;
 import com.microsoft.graph.models.extensions.Entity;

--- a/src/main/java/com/microsoft/graph/models/extensions/Thumbnail.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Thumbnail.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ThumbnailSet.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ThumbnailSet.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Thumbnail;
 import com.microsoft.graph.models.extensions.Entity;

--- a/src/main/java/com/microsoft/graph/models/extensions/TimeConstraint.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/TimeConstraint.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.ActivityDomain;
 import com.microsoft.graph.models.extensions.TimeSlot;

--- a/src/main/java/com/microsoft/graph/models/extensions/TimeOff.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/TimeOff.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.TimeOffItem;
 import com.microsoft.graph.models.extensions.ChangeTrackedEntity;

--- a/src/main/java/com/microsoft/graph/models/extensions/TimeOffItem.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/TimeOffItem.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.ScheduleEntity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/TimeOffReason.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/TimeOffReason.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.TimeOffReasonIconType;
 import com.microsoft.graph.models.extensions.ChangeTrackedEntity;

--- a/src/main/java/com/microsoft/graph/models/extensions/TimeOffRequest.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/TimeOffRequest.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.ScheduleChangeRequest;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/TimeRange.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/TimeRange.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/TimeSlot.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/TimeSlot.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.DateTimeTimeZone;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/TimeZoneBase.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/TimeZoneBase.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/TimeZoneInformation.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/TimeZoneInformation.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/TokenIssuancePolicy.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/TokenIssuancePolicy.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.StsPolicy;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/TokenLifetimePolicy.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/TokenLifetimePolicy.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.StsPolicy;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/TokenMeetingInfo.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/TokenMeetingInfo.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.MeetingInfo;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/ToneInfo.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/ToneInfo.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.Tone;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/Trending.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Trending.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.ResourceReference;
 import com.microsoft.graph.models.extensions.ResourceVisualization;

--- a/src/main/java/com/microsoft/graph/models/extensions/UnmuteParticipantOperation.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/UnmuteParticipantOperation.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.CommsOperation;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/UpdateRecordingStatusOperation.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/UpdateRecordingStatusOperation.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.CommsOperation;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/UpdateWindowsDeviceAccountActionParameter.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/UpdateWindowsDeviceAccountActionParameter.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.WindowsDeviceAccount;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/UploadSession.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/UploadSession.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/UrlAssessmentRequest.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/UrlAssessmentRequest.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.ThreatAssessmentRequest;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/UsageDetails.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/UsageDetails.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/UsedInsight.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/UsedInsight.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.UsageDetails;
 import com.microsoft.graph.models.extensions.ResourceReference;

--- a/src/main/java/com/microsoft/graph/models/extensions/User.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/User.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.AssignedLicense;
 import com.microsoft.graph.models.extensions.AssignedPlan;
@@ -46,51 +45,28 @@ import com.microsoft.graph.models.extensions.Onenote;
 import com.microsoft.graph.models.extensions.UserActivity;
 import com.microsoft.graph.models.extensions.OnlineMeeting;
 import com.microsoft.graph.models.extensions.Team;
-import com.microsoft.graph.requests.extensions.AppRoleAssignmentCollectionResponse;
 import com.microsoft.graph.requests.extensions.AppRoleAssignmentCollectionPage;
-import com.microsoft.graph.requests.extensions.DirectoryObjectCollectionResponse;
 import com.microsoft.graph.requests.extensions.DirectoryObjectCollectionPage;
-import com.microsoft.graph.requests.extensions.LicenseDetailsCollectionResponse;
 import com.microsoft.graph.requests.extensions.LicenseDetailsCollectionPage;
-import com.microsoft.graph.requests.extensions.OAuth2PermissionGrantCollectionResponse;
 import com.microsoft.graph.requests.extensions.OAuth2PermissionGrantCollectionPage;
-import com.microsoft.graph.requests.extensions.ScopedRoleMembershipCollectionResponse;
 import com.microsoft.graph.requests.extensions.ScopedRoleMembershipCollectionPage;
-import com.microsoft.graph.requests.extensions.CalendarGroupCollectionResponse;
 import com.microsoft.graph.requests.extensions.CalendarGroupCollectionPage;
-import com.microsoft.graph.requests.extensions.CalendarCollectionResponse;
 import com.microsoft.graph.requests.extensions.CalendarCollectionPage;
-import com.microsoft.graph.requests.extensions.EventCollectionResponse;
 import com.microsoft.graph.requests.extensions.EventCollectionPage;
-import com.microsoft.graph.requests.extensions.ContactFolderCollectionResponse;
 import com.microsoft.graph.requests.extensions.ContactFolderCollectionPage;
-import com.microsoft.graph.requests.extensions.ContactCollectionResponse;
 import com.microsoft.graph.requests.extensions.ContactCollectionPage;
-import com.microsoft.graph.requests.extensions.MailFolderCollectionResponse;
 import com.microsoft.graph.requests.extensions.MailFolderCollectionPage;
-import com.microsoft.graph.requests.extensions.MessageCollectionResponse;
 import com.microsoft.graph.requests.extensions.MessageCollectionPage;
-import com.microsoft.graph.requests.extensions.PersonCollectionResponse;
 import com.microsoft.graph.requests.extensions.PersonCollectionPage;
-import com.microsoft.graph.requests.extensions.ProfilePhotoCollectionResponse;
 import com.microsoft.graph.requests.extensions.ProfilePhotoCollectionPage;
-import com.microsoft.graph.requests.extensions.DriveCollectionResponse;
 import com.microsoft.graph.requests.extensions.DriveCollectionPage;
-import com.microsoft.graph.requests.extensions.SiteCollectionResponse;
 import com.microsoft.graph.requests.extensions.SiteCollectionPage;
-import com.microsoft.graph.requests.extensions.ExtensionCollectionResponse;
 import com.microsoft.graph.requests.extensions.ExtensionCollectionPage;
-import com.microsoft.graph.requests.extensions.ManagedDeviceCollectionResponse;
 import com.microsoft.graph.requests.extensions.ManagedDeviceCollectionPage;
-import com.microsoft.graph.requests.extensions.ManagedAppRegistrationCollectionResponse;
 import com.microsoft.graph.requests.extensions.ManagedAppRegistrationCollectionPage;
-import com.microsoft.graph.requests.extensions.DeviceManagementTroubleshootingEventCollectionResponse;
 import com.microsoft.graph.requests.extensions.DeviceManagementTroubleshootingEventCollectionPage;
-import com.microsoft.graph.requests.extensions.UserActivityCollectionResponse;
 import com.microsoft.graph.requests.extensions.UserActivityCollectionPage;
-import com.microsoft.graph.requests.extensions.OnlineMeetingCollectionResponse;
 import com.microsoft.graph.requests.extensions.OnlineMeetingCollectionPage;
-import com.microsoft.graph.requests.extensions.TeamCollectionResponse;
 import com.microsoft.graph.requests.extensions.TeamCollectionPage;
 
 
@@ -975,483 +951,123 @@ public class User extends DirectoryObject implements IJsonBackedObject {
 
 
         if (json.has("appRoleAssignments")) {
-            final AppRoleAssignmentCollectionResponse response = new AppRoleAssignmentCollectionResponse();
-            if (json.has("appRoleAssignments@odata.nextLink")) {
-                response.nextLink = json.get("appRoleAssignments@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("appRoleAssignments").toString(), JsonObject[].class);
-            final AppRoleAssignment[] array = new AppRoleAssignment[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), AppRoleAssignment.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            appRoleAssignments = new AppRoleAssignmentCollectionPage(response, null);
+            appRoleAssignments = serializer.deserializeObject(json.get("appRoleAssignments").toString(), AppRoleAssignmentCollectionPage.class);
         }
 
         if (json.has("createdObjects")) {
-            final DirectoryObjectCollectionResponse response = new DirectoryObjectCollectionResponse();
-            if (json.has("createdObjects@odata.nextLink")) {
-                response.nextLink = json.get("createdObjects@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("createdObjects").toString(), JsonObject[].class);
-            final DirectoryObject[] array = new DirectoryObject[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DirectoryObject.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            createdObjects = new DirectoryObjectCollectionPage(response, null);
+            createdObjects = serializer.deserializeObject(json.get("createdObjects").toString(), DirectoryObjectCollectionPage.class);
         }
 
         if (json.has("directReports")) {
-            final DirectoryObjectCollectionResponse response = new DirectoryObjectCollectionResponse();
-            if (json.has("directReports@odata.nextLink")) {
-                response.nextLink = json.get("directReports@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("directReports").toString(), JsonObject[].class);
-            final DirectoryObject[] array = new DirectoryObject[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DirectoryObject.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            directReports = new DirectoryObjectCollectionPage(response, null);
+            directReports = serializer.deserializeObject(json.get("directReports").toString(), DirectoryObjectCollectionPage.class);
         }
 
         if (json.has("licenseDetails")) {
-            final LicenseDetailsCollectionResponse response = new LicenseDetailsCollectionResponse();
-            if (json.has("licenseDetails@odata.nextLink")) {
-                response.nextLink = json.get("licenseDetails@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("licenseDetails").toString(), JsonObject[].class);
-            final LicenseDetails[] array = new LicenseDetails[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), LicenseDetails.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            licenseDetails = new LicenseDetailsCollectionPage(response, null);
+            licenseDetails = serializer.deserializeObject(json.get("licenseDetails").toString(), LicenseDetailsCollectionPage.class);
         }
 
         if (json.has("memberOf")) {
-            final DirectoryObjectCollectionResponse response = new DirectoryObjectCollectionResponse();
-            if (json.has("memberOf@odata.nextLink")) {
-                response.nextLink = json.get("memberOf@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("memberOf").toString(), JsonObject[].class);
-            final DirectoryObject[] array = new DirectoryObject[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DirectoryObject.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            memberOf = new DirectoryObjectCollectionPage(response, null);
+            memberOf = serializer.deserializeObject(json.get("memberOf").toString(), DirectoryObjectCollectionPage.class);
         }
 
         if (json.has("oauth2PermissionGrants")) {
-            final OAuth2PermissionGrantCollectionResponse response = new OAuth2PermissionGrantCollectionResponse();
-            if (json.has("oauth2PermissionGrants@odata.nextLink")) {
-                response.nextLink = json.get("oauth2PermissionGrants@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("oauth2PermissionGrants").toString(), JsonObject[].class);
-            final OAuth2PermissionGrant[] array = new OAuth2PermissionGrant[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), OAuth2PermissionGrant.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            oauth2PermissionGrants = new OAuth2PermissionGrantCollectionPage(response, null);
+            oauth2PermissionGrants = serializer.deserializeObject(json.get("oauth2PermissionGrants").toString(), OAuth2PermissionGrantCollectionPage.class);
         }
 
         if (json.has("ownedDevices")) {
-            final DirectoryObjectCollectionResponse response = new DirectoryObjectCollectionResponse();
-            if (json.has("ownedDevices@odata.nextLink")) {
-                response.nextLink = json.get("ownedDevices@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("ownedDevices").toString(), JsonObject[].class);
-            final DirectoryObject[] array = new DirectoryObject[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DirectoryObject.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            ownedDevices = new DirectoryObjectCollectionPage(response, null);
+            ownedDevices = serializer.deserializeObject(json.get("ownedDevices").toString(), DirectoryObjectCollectionPage.class);
         }
 
         if (json.has("ownedObjects")) {
-            final DirectoryObjectCollectionResponse response = new DirectoryObjectCollectionResponse();
-            if (json.has("ownedObjects@odata.nextLink")) {
-                response.nextLink = json.get("ownedObjects@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("ownedObjects").toString(), JsonObject[].class);
-            final DirectoryObject[] array = new DirectoryObject[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DirectoryObject.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            ownedObjects = new DirectoryObjectCollectionPage(response, null);
+            ownedObjects = serializer.deserializeObject(json.get("ownedObjects").toString(), DirectoryObjectCollectionPage.class);
         }
 
         if (json.has("registeredDevices")) {
-            final DirectoryObjectCollectionResponse response = new DirectoryObjectCollectionResponse();
-            if (json.has("registeredDevices@odata.nextLink")) {
-                response.nextLink = json.get("registeredDevices@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("registeredDevices").toString(), JsonObject[].class);
-            final DirectoryObject[] array = new DirectoryObject[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DirectoryObject.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            registeredDevices = new DirectoryObjectCollectionPage(response, null);
+            registeredDevices = serializer.deserializeObject(json.get("registeredDevices").toString(), DirectoryObjectCollectionPage.class);
         }
 
         if (json.has("scopedRoleMemberOf")) {
-            final ScopedRoleMembershipCollectionResponse response = new ScopedRoleMembershipCollectionResponse();
-            if (json.has("scopedRoleMemberOf@odata.nextLink")) {
-                response.nextLink = json.get("scopedRoleMemberOf@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("scopedRoleMemberOf").toString(), JsonObject[].class);
-            final ScopedRoleMembership[] array = new ScopedRoleMembership[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), ScopedRoleMembership.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            scopedRoleMemberOf = new ScopedRoleMembershipCollectionPage(response, null);
+            scopedRoleMemberOf = serializer.deserializeObject(json.get("scopedRoleMemberOf").toString(), ScopedRoleMembershipCollectionPage.class);
         }
 
         if (json.has("transitiveMemberOf")) {
-            final DirectoryObjectCollectionResponse response = new DirectoryObjectCollectionResponse();
-            if (json.has("transitiveMemberOf@odata.nextLink")) {
-                response.nextLink = json.get("transitiveMemberOf@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("transitiveMemberOf").toString(), JsonObject[].class);
-            final DirectoryObject[] array = new DirectoryObject[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DirectoryObject.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            transitiveMemberOf = new DirectoryObjectCollectionPage(response, null);
+            transitiveMemberOf = serializer.deserializeObject(json.get("transitiveMemberOf").toString(), DirectoryObjectCollectionPage.class);
         }
 
         if (json.has("calendarGroups")) {
-            final CalendarGroupCollectionResponse response = new CalendarGroupCollectionResponse();
-            if (json.has("calendarGroups@odata.nextLink")) {
-                response.nextLink = json.get("calendarGroups@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("calendarGroups").toString(), JsonObject[].class);
-            final CalendarGroup[] array = new CalendarGroup[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), CalendarGroup.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            calendarGroups = new CalendarGroupCollectionPage(response, null);
+            calendarGroups = serializer.deserializeObject(json.get("calendarGroups").toString(), CalendarGroupCollectionPage.class);
         }
 
         if (json.has("calendars")) {
-            final CalendarCollectionResponse response = new CalendarCollectionResponse();
-            if (json.has("calendars@odata.nextLink")) {
-                response.nextLink = json.get("calendars@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("calendars").toString(), JsonObject[].class);
-            final Calendar[] array = new Calendar[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), Calendar.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            calendars = new CalendarCollectionPage(response, null);
+            calendars = serializer.deserializeObject(json.get("calendars").toString(), CalendarCollectionPage.class);
         }
 
         if (json.has("calendarView")) {
-            final EventCollectionResponse response = new EventCollectionResponse();
-            if (json.has("calendarView@odata.nextLink")) {
-                response.nextLink = json.get("calendarView@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("calendarView").toString(), JsonObject[].class);
-            final Event[] array = new Event[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), Event.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            calendarView = new EventCollectionPage(response, null);
+            calendarView = serializer.deserializeObject(json.get("calendarView").toString(), EventCollectionPage.class);
         }
 
         if (json.has("contactFolders")) {
-            final ContactFolderCollectionResponse response = new ContactFolderCollectionResponse();
-            if (json.has("contactFolders@odata.nextLink")) {
-                response.nextLink = json.get("contactFolders@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("contactFolders").toString(), JsonObject[].class);
-            final ContactFolder[] array = new ContactFolder[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), ContactFolder.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            contactFolders = new ContactFolderCollectionPage(response, null);
+            contactFolders = serializer.deserializeObject(json.get("contactFolders").toString(), ContactFolderCollectionPage.class);
         }
 
         if (json.has("contacts")) {
-            final ContactCollectionResponse response = new ContactCollectionResponse();
-            if (json.has("contacts@odata.nextLink")) {
-                response.nextLink = json.get("contacts@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("contacts").toString(), JsonObject[].class);
-            final Contact[] array = new Contact[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), Contact.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            contacts = new ContactCollectionPage(response, null);
+            contacts = serializer.deserializeObject(json.get("contacts").toString(), ContactCollectionPage.class);
         }
 
         if (json.has("events")) {
-            final EventCollectionResponse response = new EventCollectionResponse();
-            if (json.has("events@odata.nextLink")) {
-                response.nextLink = json.get("events@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("events").toString(), JsonObject[].class);
-            final Event[] array = new Event[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), Event.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            events = new EventCollectionPage(response, null);
+            events = serializer.deserializeObject(json.get("events").toString(), EventCollectionPage.class);
         }
 
         if (json.has("mailFolders")) {
-            final MailFolderCollectionResponse response = new MailFolderCollectionResponse();
-            if (json.has("mailFolders@odata.nextLink")) {
-                response.nextLink = json.get("mailFolders@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("mailFolders").toString(), JsonObject[].class);
-            final MailFolder[] array = new MailFolder[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), MailFolder.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            mailFolders = new MailFolderCollectionPage(response, null);
+            mailFolders = serializer.deserializeObject(json.get("mailFolders").toString(), MailFolderCollectionPage.class);
         }
 
         if (json.has("messages")) {
-            final MessageCollectionResponse response = new MessageCollectionResponse();
-            if (json.has("messages@odata.nextLink")) {
-                response.nextLink = json.get("messages@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("messages").toString(), JsonObject[].class);
-            final Message[] array = new Message[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), Message.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            messages = new MessageCollectionPage(response, null);
+            messages = serializer.deserializeObject(json.get("messages").toString(), MessageCollectionPage.class);
         }
 
         if (json.has("people")) {
-            final PersonCollectionResponse response = new PersonCollectionResponse();
-            if (json.has("people@odata.nextLink")) {
-                response.nextLink = json.get("people@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("people").toString(), JsonObject[].class);
-            final Person[] array = new Person[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), Person.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            people = new PersonCollectionPage(response, null);
+            people = serializer.deserializeObject(json.get("people").toString(), PersonCollectionPage.class);
         }
 
         if (json.has("photos")) {
-            final ProfilePhotoCollectionResponse response = new ProfilePhotoCollectionResponse();
-            if (json.has("photos@odata.nextLink")) {
-                response.nextLink = json.get("photos@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("photos").toString(), JsonObject[].class);
-            final ProfilePhoto[] array = new ProfilePhoto[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), ProfilePhoto.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            photos = new ProfilePhotoCollectionPage(response, null);
+            photos = serializer.deserializeObject(json.get("photos").toString(), ProfilePhotoCollectionPage.class);
         }
 
         if (json.has("drives")) {
-            final DriveCollectionResponse response = new DriveCollectionResponse();
-            if (json.has("drives@odata.nextLink")) {
-                response.nextLink = json.get("drives@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("drives").toString(), JsonObject[].class);
-            final Drive[] array = new Drive[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), Drive.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            drives = new DriveCollectionPage(response, null);
+            drives = serializer.deserializeObject(json.get("drives").toString(), DriveCollectionPage.class);
         }
 
         if (json.has("followedSites")) {
-            final SiteCollectionResponse response = new SiteCollectionResponse();
-            if (json.has("followedSites@odata.nextLink")) {
-                response.nextLink = json.get("followedSites@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("followedSites").toString(), JsonObject[].class);
-            final Site[] array = new Site[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), Site.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            followedSites = new SiteCollectionPage(response, null);
+            followedSites = serializer.deserializeObject(json.get("followedSites").toString(), SiteCollectionPage.class);
         }
 
         if (json.has("extensions")) {
-            final ExtensionCollectionResponse response = new ExtensionCollectionResponse();
-            if (json.has("extensions@odata.nextLink")) {
-                response.nextLink = json.get("extensions@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("extensions").toString(), JsonObject[].class);
-            final Extension[] array = new Extension[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), Extension.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            extensions = new ExtensionCollectionPage(response, null);
+            extensions = serializer.deserializeObject(json.get("extensions").toString(), ExtensionCollectionPage.class);
         }
 
         if (json.has("managedDevices")) {
-            final ManagedDeviceCollectionResponse response = new ManagedDeviceCollectionResponse();
-            if (json.has("managedDevices@odata.nextLink")) {
-                response.nextLink = json.get("managedDevices@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("managedDevices").toString(), JsonObject[].class);
-            final ManagedDevice[] array = new ManagedDevice[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), ManagedDevice.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            managedDevices = new ManagedDeviceCollectionPage(response, null);
+            managedDevices = serializer.deserializeObject(json.get("managedDevices").toString(), ManagedDeviceCollectionPage.class);
         }
 
         if (json.has("managedAppRegistrations")) {
-            final ManagedAppRegistrationCollectionResponse response = new ManagedAppRegistrationCollectionResponse();
-            if (json.has("managedAppRegistrations@odata.nextLink")) {
-                response.nextLink = json.get("managedAppRegistrations@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("managedAppRegistrations").toString(), JsonObject[].class);
-            final ManagedAppRegistration[] array = new ManagedAppRegistration[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), ManagedAppRegistration.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            managedAppRegistrations = new ManagedAppRegistrationCollectionPage(response, null);
+            managedAppRegistrations = serializer.deserializeObject(json.get("managedAppRegistrations").toString(), ManagedAppRegistrationCollectionPage.class);
         }
 
         if (json.has("deviceManagementTroubleshootingEvents")) {
-            final DeviceManagementTroubleshootingEventCollectionResponse response = new DeviceManagementTroubleshootingEventCollectionResponse();
-            if (json.has("deviceManagementTroubleshootingEvents@odata.nextLink")) {
-                response.nextLink = json.get("deviceManagementTroubleshootingEvents@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("deviceManagementTroubleshootingEvents").toString(), JsonObject[].class);
-            final DeviceManagementTroubleshootingEvent[] array = new DeviceManagementTroubleshootingEvent[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DeviceManagementTroubleshootingEvent.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            deviceManagementTroubleshootingEvents = new DeviceManagementTroubleshootingEventCollectionPage(response, null);
+            deviceManagementTroubleshootingEvents = serializer.deserializeObject(json.get("deviceManagementTroubleshootingEvents").toString(), DeviceManagementTroubleshootingEventCollectionPage.class);
         }
 
         if (json.has("activities")) {
-            final UserActivityCollectionResponse response = new UserActivityCollectionResponse();
-            if (json.has("activities@odata.nextLink")) {
-                response.nextLink = json.get("activities@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("activities").toString(), JsonObject[].class);
-            final UserActivity[] array = new UserActivity[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), UserActivity.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            activities = new UserActivityCollectionPage(response, null);
+            activities = serializer.deserializeObject(json.get("activities").toString(), UserActivityCollectionPage.class);
         }
 
         if (json.has("onlineMeetings")) {
-            final OnlineMeetingCollectionResponse response = new OnlineMeetingCollectionResponse();
-            if (json.has("onlineMeetings@odata.nextLink")) {
-                response.nextLink = json.get("onlineMeetings@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("onlineMeetings").toString(), JsonObject[].class);
-            final OnlineMeeting[] array = new OnlineMeeting[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), OnlineMeeting.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            onlineMeetings = new OnlineMeetingCollectionPage(response, null);
+            onlineMeetings = serializer.deserializeObject(json.get("onlineMeetings").toString(), OnlineMeetingCollectionPage.class);
         }
 
         if (json.has("joinedTeams")) {
-            final TeamCollectionResponse response = new TeamCollectionResponse();
-            if (json.has("joinedTeams@odata.nextLink")) {
-                response.nextLink = json.get("joinedTeams@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("joinedTeams").toString(), JsonObject[].class);
-            final Team[] array = new Team[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), Team.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            joinedTeams = new TeamCollectionPage(response, null);
+            joinedTeams = serializer.deserializeObject(json.get("joinedTeams").toString(), TeamCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/UserActivity.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/UserActivity.java
@@ -6,13 +6,11 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.Status;
 import com.microsoft.graph.models.extensions.VisualInfo;
 import com.microsoft.graph.models.extensions.ActivityHistoryItem;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.ActivityHistoryItemCollectionResponse;
 import com.microsoft.graph.requests.extensions.ActivityHistoryItemCollectionPage;
 
 
@@ -181,19 +179,7 @@ public class UserActivity extends Entity implements IJsonBackedObject {
 
 
         if (json.has("historyItems")) {
-            final ActivityHistoryItemCollectionResponse response = new ActivityHistoryItemCollectionResponse();
-            if (json.has("historyItems@odata.nextLink")) {
-                response.nextLink = json.get("historyItems@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("historyItems").toString(), JsonObject[].class);
-            final ActivityHistoryItem[] array = new ActivityHistoryItem[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), ActivityHistoryItem.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            historyItems = new ActivityHistoryItemCollectionPage(response, null);
+            historyItems = serializer.deserializeObject(json.get("historyItems").toString(), ActivityHistoryItemCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/UserIdentity.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/UserIdentity.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/UserInstallStateSummary.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/UserInstallStateSummary.java
@@ -6,11 +6,9 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.DeviceInstallState;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.DeviceInstallStateCollectionResponse;
 import com.microsoft.graph.requests.extensions.DeviceInstallStateCollectionPage;
 
 
@@ -107,19 +105,7 @@ public class UserInstallStateSummary extends Entity implements IJsonBackedObject
 
 
         if (json.has("deviceStates")) {
-            final DeviceInstallStateCollectionResponse response = new DeviceInstallStateCollectionResponse();
-            if (json.has("deviceStates@odata.nextLink")) {
-                response.nextLink = json.get("deviceStates@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("deviceStates").toString(), JsonObject[].class);
-            final DeviceInstallState[] array = new DeviceInstallState[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), DeviceInstallState.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            deviceStates = new DeviceInstallStateCollectionPage(response, null);
+            deviceStates = serializer.deserializeObject(json.get("deviceStates").toString(), DeviceInstallStateCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/UserSecurityState.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/UserSecurityState.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.EmailRole;
 import com.microsoft.graph.models.generated.LogonType;

--- a/src/main/java/com/microsoft/graph/models/extensions/UserSettings.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/UserSettings.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.ShiftPreferences;
 import com.microsoft.graph.models.extensions.Entity;

--- a/src/main/java/com/microsoft/graph/models/extensions/VerifiedDomain.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/VerifiedDomain.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/Video.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Video.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/VisualInfo.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/VisualInfo.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.ImageInfo;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/VppLicensingType.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/VppLicensingType.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/VppToken.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/VppToken.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.VppTokenSyncStatus;
 import com.microsoft.graph.models.generated.VppTokenState;

--- a/src/main/java/com/microsoft/graph/models/extensions/VulnerabilityState.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/VulnerabilityState.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/WebApp.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WebApp.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.MobileApp;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/WebApplication.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WebApplication.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.ImplicitGrantSettings;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/Website.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Website.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.WebsiteType;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/Win32LobApp.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Win32LobApp.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.WindowsArchitecture;
 import com.microsoft.graph.models.extensions.Win32LobAppInstallExperience;

--- a/src/main/java/com/microsoft/graph/models/extensions/Win32LobAppAssignmentSettings.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Win32LobAppAssignmentSettings.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.MobileAppInstallTimeSettings;
 import com.microsoft.graph.models.generated.Win32LobAppNotification;

--- a/src/main/java/com/microsoft/graph/models/extensions/Win32LobAppFileSystemRule.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Win32LobAppFileSystemRule.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.Win32LobAppFileSystemOperationType;
 import com.microsoft.graph.models.generated.Win32LobAppRuleOperator;

--- a/src/main/java/com/microsoft/graph/models/extensions/Win32LobAppInstallExperience.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Win32LobAppInstallExperience.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.Win32LobAppRestartBehavior;
 import com.microsoft.graph.models.generated.RunAsAccountType;

--- a/src/main/java/com/microsoft/graph/models/extensions/Win32LobAppMsiInformation.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Win32LobAppMsiInformation.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.Win32LobAppMsiPackageType;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/Win32LobAppPowerShellScriptRule.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Win32LobAppPowerShellScriptRule.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.Win32LobAppPowerShellScriptRuleOperationType;
 import com.microsoft.graph.models.generated.Win32LobAppRuleOperator;

--- a/src/main/java/com/microsoft/graph/models/extensions/Win32LobAppProductCodeRule.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Win32LobAppProductCodeRule.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.Win32LobAppRuleOperator;
 import com.microsoft.graph.models.extensions.Win32LobAppRule;

--- a/src/main/java/com/microsoft/graph/models/extensions/Win32LobAppRegistryRule.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Win32LobAppRegistryRule.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.Win32LobAppRegistryRuleOperationType;
 import com.microsoft.graph.models.generated.Win32LobAppRuleOperator;

--- a/src/main/java/com/microsoft/graph/models/extensions/Win32LobAppRestartSettings.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Win32LobAppRestartSettings.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/Win32LobAppReturnCode.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Win32LobAppReturnCode.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.Win32LobAppReturnCodeType;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/Win32LobAppRule.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Win32LobAppRule.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.Win32LobAppRuleType;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/Windows10CompliancePolicy.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Windows10CompliancePolicy.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.RequiredPasswordType;
 import com.microsoft.graph.models.extensions.DeviceCompliancePolicy;

--- a/src/main/java/com/microsoft/graph/models/extensions/Windows10CustomConfiguration.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Windows10CustomConfiguration.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.OmaSetting;
 import com.microsoft.graph.models.extensions.DeviceConfiguration;

--- a/src/main/java/com/microsoft/graph/models/extensions/Windows10EndpointProtectionConfiguration.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Windows10EndpointProtectionConfiguration.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.ApplicationGuardBlockClipboardSharingType;
 import com.microsoft.graph.models.generated.ApplicationGuardBlockFileTransferType;

--- a/src/main/java/com/microsoft/graph/models/extensions/Windows10EnterpriseModernAppManagementConfiguration.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Windows10EnterpriseModernAppManagementConfiguration.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.DeviceConfiguration;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/Windows10GeneralConfiguration.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Windows10GeneralConfiguration.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.StateManagementSetting;
 import com.microsoft.graph.models.generated.DefenderCloudBlockLevelType;

--- a/src/main/java/com/microsoft/graph/models/extensions/Windows10MobileCompliancePolicy.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Windows10MobileCompliancePolicy.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.RequiredPasswordType;
 import com.microsoft.graph.models.extensions.DeviceCompliancePolicy;

--- a/src/main/java/com/microsoft/graph/models/extensions/Windows10NetworkProxyServer.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Windows10NetworkProxyServer.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/Windows10SecureAssessmentConfiguration.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Windows10SecureAssessmentConfiguration.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.DeviceConfiguration;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/Windows10TeamGeneralConfiguration.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Windows10TeamGeneralConfiguration.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.MiracastChannel;
 import com.microsoft.graph.models.generated.WelcomeScreenMeetingInformation;

--- a/src/main/java/com/microsoft/graph/models/extensions/Windows81CompliancePolicy.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Windows81CompliancePolicy.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.RequiredPasswordType;
 import com.microsoft.graph.models.extensions.DeviceCompliancePolicy;

--- a/src/main/java/com/microsoft/graph/models/extensions/Windows81GeneralConfiguration.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Windows81GeneralConfiguration.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.InternetSiteSecurityLevel;
 import com.microsoft.graph.models.generated.SiteSecurityLevel;

--- a/src/main/java/com/microsoft/graph/models/extensions/WindowsDefenderAdvancedThreatProtectionConfiguration.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WindowsDefenderAdvancedThreatProtectionConfiguration.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.DeviceConfiguration;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/WindowsDefenderScanActionResult.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WindowsDefenderScanActionResult.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.DeviceActionResult;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/WindowsDeviceADAccount.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WindowsDeviceADAccount.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.WindowsDeviceAccount;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/WindowsDeviceAccount.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WindowsDeviceAccount.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/WindowsDeviceAzureADAccount.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WindowsDeviceAzureADAccount.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.WindowsDeviceAccount;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/WindowsFirewallNetworkProfile.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WindowsFirewallNetworkProfile.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.StateManagementSetting;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/WindowsInformationProtection.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WindowsInformationProtection.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.WindowsInformationProtectionDataRecoveryCertificate;
 import com.microsoft.graph.models.generated.WindowsInformationProtectionEnforcementLevel;
@@ -17,9 +16,7 @@ import com.microsoft.graph.models.extensions.WindowsInformationProtectionApp;
 import com.microsoft.graph.models.extensions.TargetedManagedAppPolicyAssignment;
 import com.microsoft.graph.models.extensions.WindowsInformationProtectionAppLockerFile;
 import com.microsoft.graph.models.extensions.ManagedAppPolicy;
-import com.microsoft.graph.requests.extensions.TargetedManagedAppPolicyAssignmentCollectionResponse;
 import com.microsoft.graph.requests.extensions.TargetedManagedAppPolicyAssignmentCollectionPage;
-import com.microsoft.graph.requests.extensions.WindowsInformationProtectionAppLockerFileCollectionResponse;
 import com.microsoft.graph.requests.extensions.WindowsInformationProtectionAppLockerFileCollectionPage;
 
 
@@ -276,51 +273,15 @@ public class WindowsInformationProtection extends ManagedAppPolicy implements IJ
 
 
         if (json.has("assignments")) {
-            final TargetedManagedAppPolicyAssignmentCollectionResponse response = new TargetedManagedAppPolicyAssignmentCollectionResponse();
-            if (json.has("assignments@odata.nextLink")) {
-                response.nextLink = json.get("assignments@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("assignments").toString(), JsonObject[].class);
-            final TargetedManagedAppPolicyAssignment[] array = new TargetedManagedAppPolicyAssignment[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), TargetedManagedAppPolicyAssignment.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            assignments = new TargetedManagedAppPolicyAssignmentCollectionPage(response, null);
+            assignments = serializer.deserializeObject(json.get("assignments").toString(), TargetedManagedAppPolicyAssignmentCollectionPage.class);
         }
 
         if (json.has("exemptAppLockerFiles")) {
-            final WindowsInformationProtectionAppLockerFileCollectionResponse response = new WindowsInformationProtectionAppLockerFileCollectionResponse();
-            if (json.has("exemptAppLockerFiles@odata.nextLink")) {
-                response.nextLink = json.get("exemptAppLockerFiles@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("exemptAppLockerFiles").toString(), JsonObject[].class);
-            final WindowsInformationProtectionAppLockerFile[] array = new WindowsInformationProtectionAppLockerFile[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), WindowsInformationProtectionAppLockerFile.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            exemptAppLockerFiles = new WindowsInformationProtectionAppLockerFileCollectionPage(response, null);
+            exemptAppLockerFiles = serializer.deserializeObject(json.get("exemptAppLockerFiles").toString(), WindowsInformationProtectionAppLockerFileCollectionPage.class);
         }
 
         if (json.has("protectedAppLockerFiles")) {
-            final WindowsInformationProtectionAppLockerFileCollectionResponse response = new WindowsInformationProtectionAppLockerFileCollectionResponse();
-            if (json.has("protectedAppLockerFiles@odata.nextLink")) {
-                response.nextLink = json.get("protectedAppLockerFiles@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("protectedAppLockerFiles").toString(), JsonObject[].class);
-            final WindowsInformationProtectionAppLockerFile[] array = new WindowsInformationProtectionAppLockerFile[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), WindowsInformationProtectionAppLockerFile.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            protectedAppLockerFiles = new WindowsInformationProtectionAppLockerFileCollectionPage(response, null);
+            protectedAppLockerFiles = serializer.deserializeObject(json.get("protectedAppLockerFiles").toString(), WindowsInformationProtectionAppLockerFileCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/WindowsInformationProtectionApp.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WindowsInformationProtectionApp.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/WindowsInformationProtectionAppLearningSummary.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WindowsInformationProtectionAppLearningSummary.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.ApplicationType;
 import com.microsoft.graph.models.extensions.Entity;

--- a/src/main/java/com/microsoft/graph/models/extensions/WindowsInformationProtectionAppLockerFile.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WindowsInformationProtectionAppLockerFile.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Entity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/WindowsInformationProtectionDataRecoveryCertificate.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WindowsInformationProtectionDataRecoveryCertificate.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/WindowsInformationProtectionDesktopApp.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WindowsInformationProtectionDesktopApp.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.WindowsInformationProtectionApp;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/WindowsInformationProtectionIPRangeCollection.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WindowsInformationProtectionIPRangeCollection.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.IpRange;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/WindowsInformationProtectionNetworkLearningSummary.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WindowsInformationProtectionNetworkLearningSummary.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Entity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/WindowsInformationProtectionPolicy.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WindowsInformationProtectionPolicy.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.WindowsInformationProtectionPinCharacterRequirements;
 import com.microsoft.graph.models.extensions.WindowsInformationProtection;

--- a/src/main/java/com/microsoft/graph/models/extensions/WindowsInformationProtectionProxiedDomainCollection.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WindowsInformationProtectionProxiedDomainCollection.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.ProxiedDomain;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/WindowsInformationProtectionResourceCollection.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WindowsInformationProtectionResourceCollection.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/WindowsInformationProtectionStoreApp.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WindowsInformationProtectionStoreApp.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.WindowsInformationProtectionApp;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/WindowsMinimumOperatingSystem.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WindowsMinimumOperatingSystem.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/WindowsMobileMSI.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WindowsMobileMSI.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.MobileLobApp;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/WindowsPhone81CompliancePolicy.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WindowsPhone81CompliancePolicy.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.RequiredPasswordType;
 import com.microsoft.graph.models.extensions.DeviceCompliancePolicy;

--- a/src/main/java/com/microsoft/graph/models/extensions/WindowsPhone81CustomConfiguration.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WindowsPhone81CustomConfiguration.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.OmaSetting;
 import com.microsoft.graph.models.extensions.DeviceConfiguration;

--- a/src/main/java/com/microsoft/graph/models/extensions/WindowsPhone81GeneralConfiguration.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WindowsPhone81GeneralConfiguration.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.AppListType;
 import com.microsoft.graph.models.extensions.AppListItem;

--- a/src/main/java/com/microsoft/graph/models/extensions/WindowsUniversalAppX.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WindowsUniversalAppX.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.WindowsArchitecture;
 import com.microsoft.graph.models.generated.WindowsDeviceType;

--- a/src/main/java/com/microsoft/graph/models/extensions/WindowsUpdateActiveHoursInstall.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WindowsUpdateActiveHoursInstall.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.WindowsUpdateInstallScheduleType;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/WindowsUpdateForBusinessConfiguration.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WindowsUpdateForBusinessConfiguration.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.AutomaticUpdateMode;
 import com.microsoft.graph.models.generated.WindowsUpdateType;

--- a/src/main/java/com/microsoft/graph/models/extensions/WindowsUpdateInstallScheduleType.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WindowsUpdateInstallScheduleType.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/WindowsUpdateScheduledInstall.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WindowsUpdateScheduledInstall.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.WeeklySchedule;
 import com.microsoft.graph.models.extensions.WindowsUpdateInstallScheduleType;

--- a/src/main/java/com/microsoft/graph/models/extensions/Workbook.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/Workbook.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.WorkbookApplication;
 import com.microsoft.graph.models.extensions.WorkbookComment;
@@ -16,15 +15,10 @@ import com.microsoft.graph.models.extensions.WorkbookOperation;
 import com.microsoft.graph.models.extensions.WorkbookTable;
 import com.microsoft.graph.models.extensions.WorkbookWorksheet;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.WorkbookCommentCollectionResponse;
 import com.microsoft.graph.requests.extensions.WorkbookCommentCollectionPage;
-import com.microsoft.graph.requests.extensions.WorkbookNamedItemCollectionResponse;
 import com.microsoft.graph.requests.extensions.WorkbookNamedItemCollectionPage;
-import com.microsoft.graph.requests.extensions.WorkbookOperationCollectionResponse;
 import com.microsoft.graph.requests.extensions.WorkbookOperationCollectionPage;
-import com.microsoft.graph.requests.extensions.WorkbookTableCollectionResponse;
 import com.microsoft.graph.requests.extensions.WorkbookTableCollectionPage;
-import com.microsoft.graph.requests.extensions.WorkbookWorksheetCollectionResponse;
 import com.microsoft.graph.requests.extensions.WorkbookWorksheetCollectionPage;
 
 
@@ -137,83 +131,23 @@ public class Workbook extends Entity implements IJsonBackedObject {
 
 
         if (json.has("comments")) {
-            final WorkbookCommentCollectionResponse response = new WorkbookCommentCollectionResponse();
-            if (json.has("comments@odata.nextLink")) {
-                response.nextLink = json.get("comments@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("comments").toString(), JsonObject[].class);
-            final WorkbookComment[] array = new WorkbookComment[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), WorkbookComment.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            comments = new WorkbookCommentCollectionPage(response, null);
+            comments = serializer.deserializeObject(json.get("comments").toString(), WorkbookCommentCollectionPage.class);
         }
 
         if (json.has("names")) {
-            final WorkbookNamedItemCollectionResponse response = new WorkbookNamedItemCollectionResponse();
-            if (json.has("names@odata.nextLink")) {
-                response.nextLink = json.get("names@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("names").toString(), JsonObject[].class);
-            final WorkbookNamedItem[] array = new WorkbookNamedItem[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), WorkbookNamedItem.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            names = new WorkbookNamedItemCollectionPage(response, null);
+            names = serializer.deserializeObject(json.get("names").toString(), WorkbookNamedItemCollectionPage.class);
         }
 
         if (json.has("operations")) {
-            final WorkbookOperationCollectionResponse response = new WorkbookOperationCollectionResponse();
-            if (json.has("operations@odata.nextLink")) {
-                response.nextLink = json.get("operations@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("operations").toString(), JsonObject[].class);
-            final WorkbookOperation[] array = new WorkbookOperation[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), WorkbookOperation.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            operations = new WorkbookOperationCollectionPage(response, null);
+            operations = serializer.deserializeObject(json.get("operations").toString(), WorkbookOperationCollectionPage.class);
         }
 
         if (json.has("tables")) {
-            final WorkbookTableCollectionResponse response = new WorkbookTableCollectionResponse();
-            if (json.has("tables@odata.nextLink")) {
-                response.nextLink = json.get("tables@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("tables").toString(), JsonObject[].class);
-            final WorkbookTable[] array = new WorkbookTable[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), WorkbookTable.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            tables = new WorkbookTableCollectionPage(response, null);
+            tables = serializer.deserializeObject(json.get("tables").toString(), WorkbookTableCollectionPage.class);
         }
 
         if (json.has("worksheets")) {
-            final WorkbookWorksheetCollectionResponse response = new WorkbookWorksheetCollectionResponse();
-            if (json.has("worksheets@odata.nextLink")) {
-                response.nextLink = json.get("worksheets@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("worksheets").toString(), JsonObject[].class);
-            final WorkbookWorksheet[] array = new WorkbookWorksheet[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), WorkbookWorksheet.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            worksheets = new WorkbookWorksheetCollectionPage(response, null);
+            worksheets = serializer.deserializeObject(json.get("worksheets").toString(), WorkbookWorksheetCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/WorkbookApplication.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WorkbookApplication.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Entity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/WorkbookChart.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WorkbookChart.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.WorkbookChartAxes;
 import com.microsoft.graph.models.extensions.WorkbookChartDataLabels;
@@ -16,7 +15,6 @@ import com.microsoft.graph.models.extensions.WorkbookChartSeries;
 import com.microsoft.graph.models.extensions.WorkbookChartTitle;
 import com.microsoft.graph.models.extensions.WorkbookWorksheet;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.WorkbookChartSeriesCollectionResponse;
 import com.microsoft.graph.requests.extensions.WorkbookChartSeriesCollectionPage;
 
 
@@ -169,19 +167,7 @@ public class WorkbookChart extends Entity implements IJsonBackedObject {
 
 
         if (json.has("series")) {
-            final WorkbookChartSeriesCollectionResponse response = new WorkbookChartSeriesCollectionResponse();
-            if (json.has("series@odata.nextLink")) {
-                response.nextLink = json.get("series@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("series").toString(), JsonObject[].class);
-            final WorkbookChartSeries[] array = new WorkbookChartSeries[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), WorkbookChartSeries.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            series = new WorkbookChartSeriesCollectionPage(response, null);
+            series = serializer.deserializeObject(json.get("series").toString(), WorkbookChartSeriesCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/WorkbookChartAreaFormat.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WorkbookChartAreaFormat.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.WorkbookChartFill;
 import com.microsoft.graph.models.extensions.WorkbookChartFont;

--- a/src/main/java/com/microsoft/graph/models/extensions/WorkbookChartAxes.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WorkbookChartAxes.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.WorkbookChartAxis;
 import com.microsoft.graph.models.extensions.Entity;

--- a/src/main/java/com/microsoft/graph/models/extensions/WorkbookChartAxis.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WorkbookChartAxis.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.WorkbookChartAxisFormat;
 import com.microsoft.graph.models.extensions.WorkbookChartGridlines;

--- a/src/main/java/com/microsoft/graph/models/extensions/WorkbookChartAxisFormat.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WorkbookChartAxisFormat.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.WorkbookChartFont;
 import com.microsoft.graph.models.extensions.WorkbookChartLineFormat;

--- a/src/main/java/com/microsoft/graph/models/extensions/WorkbookChartAxisTitle.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WorkbookChartAxisTitle.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.WorkbookChartAxisTitleFormat;
 import com.microsoft.graph.models.extensions.Entity;

--- a/src/main/java/com/microsoft/graph/models/extensions/WorkbookChartAxisTitleFormat.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WorkbookChartAxisTitleFormat.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.WorkbookChartFont;
 import com.microsoft.graph.models.extensions.Entity;

--- a/src/main/java/com/microsoft/graph/models/extensions/WorkbookChartDataLabelFormat.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WorkbookChartDataLabelFormat.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.WorkbookChartFill;
 import com.microsoft.graph.models.extensions.WorkbookChartFont;

--- a/src/main/java/com/microsoft/graph/models/extensions/WorkbookChartDataLabels.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WorkbookChartDataLabels.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.WorkbookChartDataLabelFormat;
 import com.microsoft.graph.models.extensions.Entity;

--- a/src/main/java/com/microsoft/graph/models/extensions/WorkbookChartFill.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WorkbookChartFill.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Entity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/WorkbookChartFont.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WorkbookChartFont.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Entity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/WorkbookChartGridlines.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WorkbookChartGridlines.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.WorkbookChartGridlinesFormat;
 import com.microsoft.graph.models.extensions.Entity;

--- a/src/main/java/com/microsoft/graph/models/extensions/WorkbookChartGridlinesFormat.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WorkbookChartGridlinesFormat.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.WorkbookChartLineFormat;
 import com.microsoft.graph.models.extensions.Entity;

--- a/src/main/java/com/microsoft/graph/models/extensions/WorkbookChartLegend.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WorkbookChartLegend.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.WorkbookChartLegendFormat;
 import com.microsoft.graph.models.extensions.Entity;

--- a/src/main/java/com/microsoft/graph/models/extensions/WorkbookChartLegendFormat.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WorkbookChartLegendFormat.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.WorkbookChartFill;
 import com.microsoft.graph.models.extensions.WorkbookChartFont;

--- a/src/main/java/com/microsoft/graph/models/extensions/WorkbookChartLineFormat.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WorkbookChartLineFormat.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Entity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/WorkbookChartPoint.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WorkbookChartPoint.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.WorkbookChartPointFormat;
 import com.microsoft.graph.models.extensions.Entity;

--- a/src/main/java/com/microsoft/graph/models/extensions/WorkbookChartPointFormat.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WorkbookChartPointFormat.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.WorkbookChartFill;
 import com.microsoft.graph.models.extensions.Entity;

--- a/src/main/java/com/microsoft/graph/models/extensions/WorkbookChartSeries.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WorkbookChartSeries.java
@@ -6,12 +6,10 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.WorkbookChartSeriesFormat;
 import com.microsoft.graph.models.extensions.WorkbookChartPoint;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.WorkbookChartPointCollectionResponse;
 import com.microsoft.graph.requests.extensions.WorkbookChartPointCollectionPage;
 
 
@@ -92,19 +90,7 @@ public class WorkbookChartSeries extends Entity implements IJsonBackedObject {
 
 
         if (json.has("points")) {
-            final WorkbookChartPointCollectionResponse response = new WorkbookChartPointCollectionResponse();
-            if (json.has("points@odata.nextLink")) {
-                response.nextLink = json.get("points@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("points").toString(), JsonObject[].class);
-            final WorkbookChartPoint[] array = new WorkbookChartPoint[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), WorkbookChartPoint.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            points = new WorkbookChartPointCollectionPage(response, null);
+            points = serializer.deserializeObject(json.get("points").toString(), WorkbookChartPointCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/WorkbookChartSeriesFormat.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WorkbookChartSeriesFormat.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.WorkbookChartFill;
 import com.microsoft.graph.models.extensions.WorkbookChartLineFormat;

--- a/src/main/java/com/microsoft/graph/models/extensions/WorkbookChartTitle.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WorkbookChartTitle.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.WorkbookChartTitleFormat;
 import com.microsoft.graph.models.extensions.Entity;

--- a/src/main/java/com/microsoft/graph/models/extensions/WorkbookChartTitleFormat.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WorkbookChartTitleFormat.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.WorkbookChartFill;
 import com.microsoft.graph.models.extensions.WorkbookChartFont;

--- a/src/main/java/com/microsoft/graph/models/extensions/WorkbookComment.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WorkbookComment.java
@@ -6,11 +6,9 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.WorkbookCommentReply;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.WorkbookCommentReplyCollectionResponse;
 import com.microsoft.graph.requests.extensions.WorkbookCommentReplyCollectionPage;
 
 
@@ -91,19 +89,7 @@ public class WorkbookComment extends Entity implements IJsonBackedObject {
 
 
         if (json.has("replies")) {
-            final WorkbookCommentReplyCollectionResponse response = new WorkbookCommentReplyCollectionResponse();
-            if (json.has("replies@odata.nextLink")) {
-                response.nextLink = json.get("replies@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("replies").toString(), JsonObject[].class);
-            final WorkbookCommentReply[] array = new WorkbookCommentReply[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), WorkbookCommentReply.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            replies = new WorkbookCommentReplyCollectionPage(response, null);
+            replies = serializer.deserializeObject(json.get("replies").toString(), WorkbookCommentReplyCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/WorkbookCommentReply.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WorkbookCommentReply.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Entity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/WorkbookFilter.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WorkbookFilter.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.WorkbookFilterCriteria;
 import com.microsoft.graph.models.extensions.Entity;

--- a/src/main/java/com/microsoft/graph/models/extensions/WorkbookFilterCriteria.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WorkbookFilterCriteria.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.WorkbookIcon;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/WorkbookFilterDatetime.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WorkbookFilterDatetime.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/WorkbookFormatProtection.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WorkbookFormatProtection.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Entity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/WorkbookFunctionResult.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WorkbookFunctionResult.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Entity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/WorkbookFunctions.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WorkbookFunctions.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Entity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/WorkbookIcon.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WorkbookIcon.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/WorkbookNamedItem.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WorkbookNamedItem.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.WorkbookWorksheet;
 import com.microsoft.graph.models.extensions.Entity;

--- a/src/main/java/com/microsoft/graph/models/extensions/WorkbookOperation.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WorkbookOperation.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.WorkbookOperationError;
 import com.microsoft.graph.models.generated.WorkbookOperationStatus;

--- a/src/main/java/com/microsoft/graph/models/extensions/WorkbookOperationError.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WorkbookOperationError.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.WorkbookOperationError;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/WorkbookPivotTable.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WorkbookPivotTable.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.WorkbookWorksheet;
 import com.microsoft.graph.models.extensions.Entity;

--- a/src/main/java/com/microsoft/graph/models/extensions/WorkbookRange.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WorkbookRange.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.WorkbookRangeFormat;
 import com.microsoft.graph.models.extensions.WorkbookRangeSort;

--- a/src/main/java/com/microsoft/graph/models/extensions/WorkbookRangeBorder.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WorkbookRangeBorder.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Entity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/WorkbookRangeFill.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WorkbookRangeFill.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Entity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/WorkbookRangeFont.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WorkbookRangeFont.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Entity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/WorkbookRangeFormat.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WorkbookRangeFormat.java
@@ -6,14 +6,12 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.WorkbookRangeBorder;
 import com.microsoft.graph.models.extensions.WorkbookRangeFill;
 import com.microsoft.graph.models.extensions.WorkbookRangeFont;
 import com.microsoft.graph.models.extensions.WorkbookFormatProtection;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.WorkbookRangeBorderCollectionResponse;
 import com.microsoft.graph.requests.extensions.WorkbookRangeBorderCollectionPage;
 
 
@@ -142,19 +140,7 @@ public class WorkbookRangeFormat extends Entity implements IJsonBackedObject {
 
 
         if (json.has("borders")) {
-            final WorkbookRangeBorderCollectionResponse response = new WorkbookRangeBorderCollectionResponse();
-            if (json.has("borders@odata.nextLink")) {
-                response.nextLink = json.get("borders@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("borders").toString(), JsonObject[].class);
-            final WorkbookRangeBorder[] array = new WorkbookRangeBorder[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), WorkbookRangeBorder.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            borders = new WorkbookRangeBorderCollectionPage(response, null);
+            borders = serializer.deserializeObject(json.get("borders").toString(), WorkbookRangeBorderCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/WorkbookRangeReference.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WorkbookRangeReference.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/WorkbookRangeSort.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WorkbookRangeSort.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Entity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/WorkbookRangeView.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WorkbookRangeView.java
@@ -6,11 +6,9 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.WorkbookRangeView;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.WorkbookRangeViewCollectionResponse;
 import com.microsoft.graph.requests.extensions.WorkbookRangeViewCollectionPage;
 
 
@@ -163,19 +161,7 @@ public class WorkbookRangeView extends Entity implements IJsonBackedObject {
 
 
         if (json.has("rows")) {
-            final WorkbookRangeViewCollectionResponse response = new WorkbookRangeViewCollectionResponse();
-            if (json.has("rows@odata.nextLink")) {
-                response.nextLink = json.get("rows@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("rows").toString(), JsonObject[].class);
-            final WorkbookRangeView[] array = new WorkbookRangeView[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), WorkbookRangeView.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            rows = new WorkbookRangeViewCollectionPage(response, null);
+            rows = serializer.deserializeObject(json.get("rows").toString(), WorkbookRangeViewCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/WorkbookSessionInfo.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WorkbookSessionInfo.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/WorkbookSortField.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WorkbookSortField.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.WorkbookIcon;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/WorkbookTable.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WorkbookTable.java
@@ -6,16 +6,13 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.WorkbookTableColumn;
 import com.microsoft.graph.models.extensions.WorkbookTableRow;
 import com.microsoft.graph.models.extensions.WorkbookTableSort;
 import com.microsoft.graph.models.extensions.WorkbookWorksheet;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.WorkbookTableColumnCollectionResponse;
 import com.microsoft.graph.requests.extensions.WorkbookTableColumnCollectionPage;
-import com.microsoft.graph.requests.extensions.WorkbookTableRowCollectionResponse;
 import com.microsoft.graph.requests.extensions.WorkbookTableRowCollectionPage;
 
 
@@ -184,35 +181,11 @@ public class WorkbookTable extends Entity implements IJsonBackedObject {
 
 
         if (json.has("columns")) {
-            final WorkbookTableColumnCollectionResponse response = new WorkbookTableColumnCollectionResponse();
-            if (json.has("columns@odata.nextLink")) {
-                response.nextLink = json.get("columns@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("columns").toString(), JsonObject[].class);
-            final WorkbookTableColumn[] array = new WorkbookTableColumn[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), WorkbookTableColumn.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            columns = new WorkbookTableColumnCollectionPage(response, null);
+            columns = serializer.deserializeObject(json.get("columns").toString(), WorkbookTableColumnCollectionPage.class);
         }
 
         if (json.has("rows")) {
-            final WorkbookTableRowCollectionResponse response = new WorkbookTableRowCollectionResponse();
-            if (json.has("rows@odata.nextLink")) {
-                response.nextLink = json.get("rows@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("rows").toString(), JsonObject[].class);
-            final WorkbookTableRow[] array = new WorkbookTableRow[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), WorkbookTableRow.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            rows = new WorkbookTableRowCollectionPage(response, null);
+            rows = serializer.deserializeObject(json.get("rows").toString(), WorkbookTableRowCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/WorkbookTableColumn.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WorkbookTableColumn.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.WorkbookFilter;
 import com.microsoft.graph.models.extensions.Entity;

--- a/src/main/java/com/microsoft/graph/models/extensions/WorkbookTableRow.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WorkbookTableRow.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.Entity;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/WorkbookTableSort.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WorkbookTableSort.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.WorkbookSortField;
 import com.microsoft.graph.models.extensions.Entity;

--- a/src/main/java/com/microsoft/graph/models/extensions/WorkbookWorksheet.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WorkbookWorksheet.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.WorkbookChart;
 import com.microsoft.graph.models.extensions.WorkbookNamedItem;
@@ -14,13 +13,9 @@ import com.microsoft.graph.models.extensions.WorkbookPivotTable;
 import com.microsoft.graph.models.extensions.WorkbookWorksheetProtection;
 import com.microsoft.graph.models.extensions.WorkbookTable;
 import com.microsoft.graph.models.extensions.Entity;
-import com.microsoft.graph.requests.extensions.WorkbookChartCollectionResponse;
 import com.microsoft.graph.requests.extensions.WorkbookChartCollectionPage;
-import com.microsoft.graph.requests.extensions.WorkbookNamedItemCollectionResponse;
 import com.microsoft.graph.requests.extensions.WorkbookNamedItemCollectionPage;
-import com.microsoft.graph.requests.extensions.WorkbookPivotTableCollectionResponse;
 import com.microsoft.graph.requests.extensions.WorkbookPivotTableCollectionPage;
-import com.microsoft.graph.requests.extensions.WorkbookTableCollectionResponse;
 import com.microsoft.graph.requests.extensions.WorkbookTableCollectionPage;
 
 
@@ -141,67 +136,19 @@ public class WorkbookWorksheet extends Entity implements IJsonBackedObject {
 
 
         if (json.has("charts")) {
-            final WorkbookChartCollectionResponse response = new WorkbookChartCollectionResponse();
-            if (json.has("charts@odata.nextLink")) {
-                response.nextLink = json.get("charts@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("charts").toString(), JsonObject[].class);
-            final WorkbookChart[] array = new WorkbookChart[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), WorkbookChart.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            charts = new WorkbookChartCollectionPage(response, null);
+            charts = serializer.deserializeObject(json.get("charts").toString(), WorkbookChartCollectionPage.class);
         }
 
         if (json.has("names")) {
-            final WorkbookNamedItemCollectionResponse response = new WorkbookNamedItemCollectionResponse();
-            if (json.has("names@odata.nextLink")) {
-                response.nextLink = json.get("names@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("names").toString(), JsonObject[].class);
-            final WorkbookNamedItem[] array = new WorkbookNamedItem[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), WorkbookNamedItem.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            names = new WorkbookNamedItemCollectionPage(response, null);
+            names = serializer.deserializeObject(json.get("names").toString(), WorkbookNamedItemCollectionPage.class);
         }
 
         if (json.has("pivotTables")) {
-            final WorkbookPivotTableCollectionResponse response = new WorkbookPivotTableCollectionResponse();
-            if (json.has("pivotTables@odata.nextLink")) {
-                response.nextLink = json.get("pivotTables@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("pivotTables").toString(), JsonObject[].class);
-            final WorkbookPivotTable[] array = new WorkbookPivotTable[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), WorkbookPivotTable.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            pivotTables = new WorkbookPivotTableCollectionPage(response, null);
+            pivotTables = serializer.deserializeObject(json.get("pivotTables").toString(), WorkbookPivotTableCollectionPage.class);
         }
 
         if (json.has("tables")) {
-            final WorkbookTableCollectionResponse response = new WorkbookTableCollectionResponse();
-            if (json.has("tables@odata.nextLink")) {
-                response.nextLink = json.get("tables@odata.nextLink").getAsString();
-            }
-
-            final JsonObject[] sourceArray = serializer.deserializeObject(json.get("tables").toString(), JsonObject[].class);
-            final WorkbookTable[] array = new WorkbookTable[sourceArray.length];
-            for (int i = 0; i < sourceArray.length; i++) {
-                array[i] = serializer.deserializeObject(sourceArray[i].toString(), WorkbookTable.class);
-                array[i].setRawObject(serializer, sourceArray[i]);
-            }
-            response.value = Arrays.asList(array);
-            tables = new WorkbookTableCollectionPage(response, null);
+            tables = serializer.deserializeObject(json.get("tables").toString(), WorkbookTableCollectionPage.class);
         }
     }
 }

--- a/src/main/java/com/microsoft/graph/models/extensions/WorkbookWorksheetProtection.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WorkbookWorksheetProtection.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.WorkbookWorksheetProtectionOptions;
 import com.microsoft.graph.models.extensions.Entity;

--- a/src/main/java/com/microsoft/graph/models/extensions/WorkbookWorksheetProtectionOptions.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WorkbookWorksheetProtectionOptions.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 
 

--- a/src/main/java/com/microsoft/graph/models/extensions/WorkforceIntegration.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WorkforceIntegration.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.extensions.WorkforceIntegrationEncryption;
 import com.microsoft.graph.models.generated.WorkforceIntegrationSupportedEntities;

--- a/src/main/java/com/microsoft/graph/models/extensions/WorkforceIntegrationEncryption.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WorkforceIntegrationEncryption.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.WorkforceIntegrationEncryptionProtocol;
 

--- a/src/main/java/com/microsoft/graph/models/extensions/WorkingHours.java
+++ b/src/main/java/com/microsoft/graph/models/extensions/WorkingHours.java
@@ -6,7 +6,6 @@ package com.microsoft.graph.models.extensions;
 import com.microsoft.graph.serializer.ISerializer;
 import com.microsoft.graph.serializer.IJsonBackedObject;
 import com.microsoft.graph.serializer.AdditionalDataManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import com.microsoft.graph.models.generated.DayOfWeek;
 import com.microsoft.graph.models.extensions.TimeZoneBase;

--- a/src/main/java/com/microsoft/graph/serializer/CollectionPageSerializer.java
+++ b/src/main/java/com/microsoft/graph/serializer/CollectionPageSerializer.java
@@ -105,12 +105,12 @@ public class CollectionPageSerializer {
      */
 	@SuppressWarnings("unchecked")
 	public static <T1, T2 extends IRequestBuilder> BaseCollectionPage<T1, T2> deserialize(final JsonElement json, Type typeOfT, final ILogger logger) throws JsonParseException {
-		if (json == null) {
+		if (json == null || !json.isJsonArray()) {
 			return null;
 		}
 		serializer = new DefaultSerializer(logger);
-		final JsonObject[] sourceArray = serializer.deserializeObject(json.toString(), JsonObject[].class);
-		final ArrayList<T1> list = new ArrayList<T1>(sourceArray.length);
+		final JsonArray sourceArray = json.getAsJsonArray();
+		final ArrayList<T1> list = new ArrayList<T1>(sourceArray.size());
 		/** eg: com.microsoft.graph.requests.extensions.AttachmentCollectionPage */
 		final String collectionPageClassCanonicalName = typeOfT.getTypeName();
 		/** eg: com.microsoft.graph.models.extensions.Attachment */
@@ -119,13 +119,16 @@ public class CollectionPageSerializer {
 					.replace("requests", "models");
 		try {
 			final Class<?> baseEntityClass = Class.forName(baseEntityClassCanonicalName);
-			for (JsonObject sourceObject : sourceArray) {
-				Class<?> entityClass = serializer.getDerivedClass(sourceObject, baseEntityClass);
-				if(entityClass == null)
-					entityClass = baseEntityClass;
-				final T1 targetObject = (T1)serializer.deserializeObject(sourceObject.toString(), entityClass);
-				((IJsonBackedObject)targetObject).setRawObject(serializer, sourceObject);
-				list.add(targetObject);
+			for(JsonElement sourceElement : sourceArray) {
+				if(sourceElement.isJsonObject()) {
+					final JsonObject sourceObject = sourceElement.getAsJsonObject();
+					Class<?> entityClass = serializer.getDerivedClass(sourceObject, baseEntityClass);
+					if(entityClass == null)
+						entityClass = baseEntityClass;
+					final T1 targetObject = (T1)serializer.deserializeObject(sourceObject.toString(), entityClass);
+					((IJsonBackedObject)targetObject).setRawObject(serializer, sourceObject);
+					list.add(targetObject);
+				}
 			}
 			/** eg: com.microsoft.graph.requests.extensions.AttachmentCollectionResponse */
 			final String responseClassCanonicalName = collectionPageClassCanonicalName

--- a/src/test/java/com/microsoft/graph/serializer/CollectionPageSerializerTests.java
+++ b/src/test/java/com/microsoft/graph/serializer/CollectionPageSerializerTests.java
@@ -30,6 +30,7 @@ import com.microsoft.graph.models.extensions.ItemAttachment;
 import com.microsoft.graph.models.extensions.ServicePrincipal;
 import com.microsoft.graph.models.extensions.User;
 import com.microsoft.graph.requests.extensions.AttachmentCollectionPage;
+import com.microsoft.graph.requests.extensions.EventCollectionResponse;
 import com.microsoft.graph.requests.extensions.AttachmentCollectionResponse;
 
 public class CollectionPageSerializerTests {
@@ -99,6 +100,14 @@ public class CollectionPageSerializerTests {
 		assertTrue(page.size() == 2);
 		assertTrue(page.get(0) instanceof User);
 		assertTrue(page.get(1) instanceof ServicePrincipal);
+	}
+	@Test
+	public void testEntityCollectionWithSingleValueExtendedProperties() throws Exception {
+		final String jsonString = "{\"@odata.context\": \"https://graph.microsoft.com/v1.0/$metadata#users('c2e8df37-c6a7-4d88-89b1-feb4f1fda7c5')/events\",\"@odata.nextLink\": \"https://graph.microsoft.com/v1.0/me/events?$skip=10\",\"value\": [{\"@odata.context\": \"https://graph.microsoft.com/v1.0/$metadata#Me/messages/$entity\",\"@odata.id\": \"https://graph.microsoft.com/v1.0/users('ddfcd489-628b-40d7-b48b-57002df800e5@1717622f-1d94-4d0c-9d74-709fad664b77')/messages('AAMkAGE1M2_bs88AACHsLqWAAA=')\",\"@odata.etag\": \"W/\\\"CQAAABYAAACY4MQpaFz9SbqUDe4+bs88AACbyS4H\\\"\",\"id\": \"AAMkAGE1M2_bs88AACHsLqWAAA=\",\"subject\": \"RE: Talk about emergency prep\",\"sender\": {\"emailAddress\": {\"name\": \"Christine Irwin\",\"address\": \"christine@contoso.com\"}},\"from\": null,\"toRecipients\": [{\"emailAddress\": {\"name\": \"Christine Irwin\",\"address\": \"christine@contoso.com\"}}],\"singleValueExtendedProperties@odata.context\": \"https://graph.microsoft.com/v1.0/$metadata#Me/messages('AAMkAGE1M2_bs88AACHsLqWAAA%3D')/singleValueExtendedProperties\",\"singleValueExtendedProperties\": [{\"id\": \"String {66f5a359-4659-4830-9070-00047ec6ac6e} Name Color\",\"value\": \"Green\"}]}]}";
+		final DefaultSerializer defaultSerializer = new DefaultSerializer(logger);
+		final EventCollectionResponse events = defaultSerializer.deserializeObject(jsonString, EventCollectionResponse.class);
+		assertNotNull(events);
+		assertTrue(events.value.get(0).singleValueExtendedProperties.getCurrentPage().size() > 0);
 	}
 
 	private FileAttachment getFileAttachment() throws Exception{


### PR DESCRIPTION
fixes #475 

Note: In this PR you'll see that I'm removing the `propertyName@odata.nextlink` parsing. That is because it was passed to the response object and then never used. On top of that the builder was never instanciated (where the next link should be passed) and that's because the client is not available in the entity class.