### PR TITLE
- disables dependabot for the pom/maven placeholder file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,3 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
-- package-ecosystem: maven
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10


### PR DESCRIPTION
related #514
closes #518

The introduction of a placeholder pom for the dependency graph turned on dependabot for that dependencies manager. This PR disbales it