### PR TITLE
- fixes #568: a bug where time duration deserialization would fail because of quotes

### DIFF
--- a/src/main/java/com/microsoft/graph/serializer/GsonFactory.java
+++ b/src/main/java/com/microsoft/graph/serializer/GsonFactory.java
@@ -205,7 +205,7 @@ final class GsonFactory {
                                        final Type typeOfT,
                                        final JsonDeserializationContext context) throws JsonParseException {
                 try {
-                    return DatatypeFactory.newInstance().newDuration(json.toString());
+                    return DatatypeFactory.newInstance().newDuration(json.getAsString());
                 } catch (Exception e) {
                     return null;
                 }

--- a/src/test/java/com/microsoft/graph/serializer/DefaultSerializerTests.java
+++ b/src/test/java/com/microsoft/graph/serializer/DefaultSerializerTests.java
@@ -8,6 +8,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.microsoft.graph.callrecords.models.extensions.MediaStream;
 import com.microsoft.graph.http.MockConnection;
 import com.microsoft.graph.logger.DefaultLogger;
 import com.microsoft.graph.models.extensions.Attachment;
@@ -163,6 +164,14 @@ public class DefaultSerializerTests {
         assertNotNull(result);
         assertNotNull(result.nextExpectedRanges);
         assertTrue(result.nextExpectedRanges.size() > 0);
+    }
+    @Test
+    public void testDurationDeserialization() {
+        final DefaultSerializer serializer = new DefaultSerializer(new DefaultLogger());
+        final String source = "{\"streamId\": \"2101\",\"startDateTime\": null,\"endDateTime\": null,\"streamDirection\": \"calleeToCaller\",\"averageAudioDegradation\": null,\"averageJitter\": \"PT0.004S\",\"maxJitter\": \"PT0.007S\",\"averagePacketLossRate\": 0,\"maxPacketLossRate\": 0,\"averageRatioOfConcealedSamples\": 0,\"maxRatioOfConcealedSamples\": null,\"averageRoundTripTime\": \"PT0.024S\",\"maxRoundTripTime\": \"PT0.05S\",\"packetUtilization\": 471,\"averageBandwidthEstimate\": 1174971,\"wasMediaBypassed\": null,\"postForwardErrorCorrectionPacketLossRate\": null,\"averageVideoFrameLossPercentage\": null,\"averageReceivedFrameRate\": null,\"lowFrameRateRatio\": null,\"averageVideoPacketLossRate\": null,\"averageVideoFrameRate\": null,\"lowVideoProcessingCapabilityRatio\": null,\"averageAudioNetworkJitter\": \"PT0.014S\",\"maxAudioNetworkJitter\": \"PT0.022S\"}";
+        final MediaStream result = serializer.deserializeObject(source, MediaStream.class);
+        assertNotNull(result);
+        assertNotNull(result.maxRoundTripTime);
     }
   
   public static final class HasVoidMember {


### PR DESCRIPTION
fixes #568 a bug where duration deserlization would fail because of quotes