### PR TITLE
feature/guava-update

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ repositories {
 dependencies {
     // Include the sdk as a dependency
     implementation 'com.microsoft.graph:microsoft-graph:2.3.+'
+    // Uncomment the line below if you are building an android application
+    //implementation 'com.google.guava:guava:29.0-android'
 }
 ```
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,5 +1,5 @@
 dependencies {
-	implementation 'com.google.guava:guava:23.0'
+	implementation 'com.google.guava:guava:29.0-jre'
 
     // Use JUnit test framework
     testImplementation 'junit:junit:4.13.1'

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>23.0</version>
+			<version>29.0-jre</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
fixes https://github.com/microsoftgraph/msgraph-sdk-java/network/alert/pom.xml/com.google.guava:guava/open

guava  splits their assets per version to have a  java 8 compatible version (-jre) and a android /java7 compatible version (-android)

Thanks to how the dependency resolution works on maven and gradle:

- java developers will be able to use the library as is
- android developers need to add an additional dependency line (updated the readme) so gradle builds using the deduped version  that will point to the android assets instead.

We could alternatively use the android asset, it might translate to performance degradation for java developers though.
We could alternatively  use variants and publish android and java assets, it'll complexify maintenance and troubleshooting with customers though.

More reading :

- https://docs.gradle.org/current/userguide/library_vs_application.html
- https://docs.gradle.org/current/userguide/dependency_downgrade_and_exclude.htm