### PR TITLE
- moves the properties file to the right folder to apply configuration and avoid heap exceptions

### DIFF
--- a/typesummary/app/gradle.properties
+++ b/typesummary/app/gradle.properties
@@ -1,3 +1,0 @@
-org.gradle.jvmargs=-XX:MaxPermSize=512m -Xmx2g
-org.gradle.parallel=true
-org.gradle.caching=true

--- a/typesummary/gradle.properties
+++ b/typesummary/gradle.properties
@@ -1,0 +1,4 @@
+org.gradle.jvmargs=-Xms128m -XX:MaxPermSize=2048m -Xmx8g
+org.gradle.configureondemand=true
+org.gradle.parallel=true
+org.gradle.caching=true


### PR DESCRIPTION
the gradle.properties for the typesummary project was not at the right place.
This lead to the JVM not being configured properly and running into heap exceptions.
The issue was detected on the beta SDK as it contains much more code