### PR TITLE
Fix BaseCollectionRequest setMaxRetries method

### DIFF
--- a/src/main/java/com/microsoft/graph/http/BaseCollectionRequest.java
+++ b/src/main/java/com/microsoft/graph/http/BaseCollectionRequest.java
@@ -271,7 +271,7 @@ public abstract class BaseCollectionRequest<T1, T2> implements IHttpRequest {
      * @param maxRetries Max retries for a request
      */
     public void setMaxRetries(int maxRetries) {
-    	baseRequest.setMaxRedirects(maxRetries);
+    	baseRequest.setMaxRetries(maxRetries);
     }
     
     /**


### PR DESCRIPTION
Fixes #659

<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request
- Fix typo in BaseCollectionRequest setMaxRetries method, which caused the maximum redirects to be set instead of  maximum retries