### PR TITLE
If an error is available during upload report this in the ClientExcep…

### DIFF
--- a/src/main/java/com/microsoft/graph/requests/extensions/ChunkedUploadRequest.java
+++ b/src/main/java/com/microsoft/graph/requests/extensions/ChunkedUploadRequest.java
@@ -111,8 +111,8 @@ public class ChunkedUploadRequest {
 
         if (result != null && result.chunkCompleted()) {
             return result;
-        } else 
+        } else
             return new ChunkedUploadResult<UploadType>(
-                new ClientException("Upload session failed.", null));
+                new ClientException("Upload session failed.", result != null ? result.getError() : null));
     }
 }

--- a/src/main/java/com/microsoft/graph/requests/extensions/ChunkedUploadRequest.java
+++ b/src/main/java/com/microsoft/graph/requests/extensions/ChunkedUploadRequest.java
@@ -113,6 +113,6 @@ public class ChunkedUploadRequest {
             return result;
         } else
             return new ChunkedUploadResult<UploadType>(
-                new ClientException("Upload session failed.", result != null ? result.getError() : null));
+                new ClientException("Upload session failed.", result == null ? null : result.getError()));
     }
 }


### PR DESCRIPTION
During testing of the ChunkedUploadProvider.upload() method, an error in the callback was being created. However, this error is being swallowed by the ChunkedUploadRequest class, and not reported back through the exception handling. This change is to pass the original error back to the calling code. This would be much more helpful in debugging errors occurring in the callback handling.