### PR TITLE
bugfix/default content type and boolean deserialization

### DIFF
--- a/src/main/java/com/microsoft/graph/http/CoreHttpProvider.java
+++ b/src/main/java/com/microsoft/graph/http/CoreHttpProvider.java
@@ -243,7 +243,7 @@ public class CoreHttpProvider implements IHttpProvider {
 		if(this.connectionConfig == null) {
 			this.connectionConfig = new DefaultConnectionConfig();
 		}
-		
+
 		// Request level middleware options
 		RedirectOptions redirectOptions = new RedirectOptions(request.getMaxRedirects() > 0? request.getMaxRedirects() : this.connectionConfig.getMaxRedirects(),
 				request.getShouldRedirect() != null? request.getShouldRedirect() : this.connectionConfig.getShouldRedirect());
@@ -256,7 +256,7 @@ public class CoreHttpProvider implements IHttpProvider {
 				.newBuilder()
 				.tag(RedirectOptions.class, redirectOptions)
 				.tag(RetryOptions.class, retryOptions);
-		
+
 		String contenttype = null;
 
 		logger.logDebug("Request Method " + request.getHttpMethod().toString());
@@ -276,11 +276,7 @@ public class CoreHttpProvider implements IHttpProvider {
 			// This ensures that the Content-Length header is properly set
 			if (request.getHttpMethod() == HttpMethod.POST) {
 				bytesToWrite = new byte[0];
-				if(contenttype == null) {
-					contenttype = Constants.BINARY_CONTENT_TYPE;
-				}
-			}
-			else {
+			} else {
 				bytesToWrite = null;
 			}
 		} else if (serializable instanceof byte[]) {
@@ -341,7 +337,11 @@ public class CoreHttpProvider implements IHttpProvider {
 
 				@Override
 				public MediaType contentType() {
-					return MediaType.parse(mediaContentType);
+                    if(mediaContentType == null || mediaContentType.isEmpty()) {
+                        return null;
+                    } else {
+					    return MediaType.parse(mediaContentType);
+                    }
 				}
 			};
 		}
@@ -401,7 +401,7 @@ public class CoreHttpProvider implements IHttpProvider {
 			try {
 
 				// Call being executed
-				
+
 
 				if (handler != null) {
 					handler.configConnection(response);
@@ -425,7 +425,7 @@ public class CoreHttpProvider implements IHttpProvider {
 
 				if (response.code() == HttpResponseCode.HTTP_NOBODY
 						|| response.code() == HttpResponseCode.HTTP_NOT_MODIFIED) {
-					logger.logDebug("Handling response with no body");                  
+					logger.logDebug("Handling response with no body");
 					return handleEmptyResponse(responseHeadersHelper.getResponseHeadersAsMapOfStringList(response), resultClass);
 				}
 
@@ -442,7 +442,7 @@ public class CoreHttpProvider implements IHttpProvider {
 					return (Result) null;
 
 				final String contentType = headers.get(Constants.CONTENT_TYPE_HEADER_NAME);
-				if (contentType != null && resultClass != InputStream.class && 
+				if (contentType != null && resultClass != InputStream.class &&
 							contentType.contains(Constants.JSON_CONTENT_TYPE)) {
 					logger.logDebug("Response json");
 					return handleJsonResponse(in, responseHeadersHelper.getResponseHeadersAsMapOfStringList(response), resultClass);
@@ -534,12 +534,12 @@ public class CoreHttpProvider implements IHttpProvider {
 
 	/**
 	 * Handles the case where the response body is empty
-	 * 
+	 *
 	 * @param responseHeaders the response headers
 	 * @param clazz           the type of the response object
 	 * @return                the JSON object
 	 */
-	private <Result> Result handleEmptyResponse(Map<String, List<String>> responseHeaders, final Class<Result> clazz) 
+	private <Result> Result handleEmptyResponse(Map<String, List<String>> responseHeaders, final Class<Result> clazz)
 			throws UnsupportedEncodingException{
 		//Create an empty object to attach the response headers to
 		InputStream in = new ByteArrayInputStream("{}".getBytes(Constants.JSON_ENCODING));

--- a/src/main/java/com/microsoft/graph/serializer/EdmNativeTypeSerializer.java
+++ b/src/main/java/com/microsoft/graph/serializer/EdmNativeTypeSerializer.java
@@ -10,7 +10,7 @@ import com.microsoft.graph.logger.ILogger;
 
 public class EdmNativeTypeSerializer {
     public static <T> T deserialize(final JsonElement json, final Class<T> type, final ILogger logger) throws JsonParseException {
-        if (json == null || !(type instanceof Class)) {
+        if (json == null || type == null) {
 			return null;
         } else if(json.isJsonPrimitive()) {
             return getPrimitiveValue(json, type);

--- a/src/main/java/com/microsoft/graph/serializer/EdmNativeTypeSerializer.java
+++ b/src/main/java/com/microsoft/graph/serializer/EdmNativeTypeSerializer.java
@@ -1,0 +1,47 @@
+package com.microsoft.graph.serializer;
+
+import java.lang.reflect.Type;
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+import com.microsoft.graph.logger.ILogger;
+
+public class EdmNativeTypeSerializer {
+    public static <T> T deserialize(final JsonElement json, final Class<T> type, final ILogger logger) throws JsonParseException {
+        if (json == null || !(type instanceof Class)) {
+			return null;
+        } else if(json.isJsonPrimitive()) {
+            return getPrimitiveValue(json, type);
+		} else if(json.isJsonObject()) {
+            final JsonElement element = json.getAsJsonObject().get("@odata.null");
+            if(element != null && element.isJsonPrimitive()) {
+                return getPrimitiveValue(element, type);
+            } else {
+                return null;
+            }
+        }
+        return null;
+    }
+    @SuppressWarnings("unchecked")
+    private static <T> T getPrimitiveValue(final JsonElement json, final Class<T> type) {
+        if(type == Boolean.class) {
+            return (T) Boolean.valueOf(json.getAsBoolean());
+        } else if(type == String.class) {
+            return (T)json.getAsString();
+        } else if(type == Integer.class) {
+            return (T) Integer.valueOf(json.getAsInt());
+        } else if(type == UUID.class) {
+            return (T) UUID.fromString(json.getAsString());
+        } else if(type == Long.class) {
+            return (T) Long.valueOf(json.getAsLong());
+        } else if (type == Float.class) {
+            return (T) Float.valueOf(json.getAsFloat());
+        } else if (type == BigDecimal.class) {
+            return (T) json.getAsBigDecimal();
+        } else {
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/microsoft/graph/serializer/GsonFactory.java
+++ b/src/main/java/com/microsoft/graph/serializer/GsonFactory.java
@@ -37,10 +37,12 @@ import com.microsoft.graph.models.extensions.DateOnly;
 
 import com.microsoft.graph.models.extensions.TimeOfDay;
 import java.lang.reflect.Type;
+import java.math.BigDecimal;
 import java.text.ParseException;
 import java.util.Calendar;
 import java.util.EnumSet;
 import java.util.GregorianCalendar;
+import java.util.UUID;
 
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.Duration;
@@ -244,8 +246,78 @@ final class GsonFactory {
             }
         };
 
+        final JsonDeserializer<Boolean> booleanJsonDeserializer = new JsonDeserializer<Boolean>() {
+            @Override
+            public Boolean deserialize(final JsonElement json,
+                    final Type typeOfT,
+                    final JsonDeserializationContext context) throws JsonParseException {
+                    return EdmNativeTypeSerializer.deserialize(json, Boolean.class, logger);
+            }
+        };
+
+        final JsonDeserializer<String> stringJsonDeserializer = new JsonDeserializer<String>() {
+            @Override
+            public String deserialize(final JsonElement json,
+                    final Type typeOfT,
+                    final JsonDeserializationContext context) throws JsonParseException {
+                    return EdmNativeTypeSerializer.deserialize(json, String.class, logger);
+            }
+        };
+
+        final JsonDeserializer<BigDecimal> bigDecimalJsonDeserializer = new JsonDeserializer<BigDecimal>() {
+            @Override
+            public BigDecimal deserialize(final JsonElement json,
+                    final Type typeOfT,
+                    final JsonDeserializationContext context) throws JsonParseException {
+                    return EdmNativeTypeSerializer.deserialize(json, BigDecimal.class, logger);
+            }
+        };
+
+        final JsonDeserializer<Integer> integerJsonDeserializer = new JsonDeserializer<Integer>() {
+            @Override
+            public Integer deserialize(final JsonElement json,
+                    final Type typeOfT,
+                    final JsonDeserializationContext context) throws JsonParseException {
+                    return EdmNativeTypeSerializer.deserialize(json, Integer.class, logger);
+            }
+        };
+
+        final JsonDeserializer<Long> longJsonDeserializer = new JsonDeserializer<Long>() {
+            @Override
+            public Long deserialize(final JsonElement json,
+                    final Type typeOfT,
+                    final JsonDeserializationContext context) throws JsonParseException {
+                    return EdmNativeTypeSerializer.deserialize(json, Long.class, logger);
+            }
+        };
+
+        final JsonDeserializer<UUID> uuidJsonDeserializer = new JsonDeserializer<UUID>() {
+            @Override
+            public UUID deserialize(final JsonElement json,
+                    final Type typeOfT,
+                    final JsonDeserializationContext context) throws JsonParseException {
+                    return EdmNativeTypeSerializer.deserialize(json, UUID.class, logger);
+            }
+        };
+
+        final JsonDeserializer<Float> floatJsonDeserializer = new JsonDeserializer<Float>() {
+            @Override
+            public Float deserialize(final JsonElement json,
+                    final Type typeOfT,
+                    final JsonDeserializationContext context) throws JsonParseException {
+                    return EdmNativeTypeSerializer.deserialize(json, Float.class, logger);
+            }
+        };
+
         return new GsonBuilder()
                 .excludeFieldsWithoutExposeAnnotation()
+                .registerTypeAdapter(Boolean.class, booleanJsonDeserializer)
+                .registerTypeAdapter(String.class, stringJsonDeserializer)
+                .registerTypeAdapter(Float.class, floatJsonDeserializer)
+                .registerTypeAdapter(Integer.class, integerJsonDeserializer)
+                .registerTypeAdapter(BigDecimal.class, bigDecimalJsonDeserializer)
+                .registerTypeAdapter(UUID.class, uuidJsonDeserializer)
+                .registerTypeAdapter(Long.class, longJsonDeserializer)
                 .registerTypeAdapter(Calendar.class, calendarJsonSerializer)
                 .registerTypeAdapter(Calendar.class, calendarJsonDeserializer)
                 .registerTypeAdapter(GregorianCalendar.class, calendarJsonSerializer)

--- a/src/test/java/com/microsoft/graph/functional/UserTests.java
+++ b/src/test/java/com/microsoft/graph/functional/UserTests.java
@@ -3,6 +3,7 @@ package com.microsoft.graph.functional;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -160,7 +161,7 @@ public class UserTests {
 		IUsedInsightCollectionPage usedInsightCollectionPage = graphServiceClient.me().insights().used().buildRequest().get();
 		assertNotNull(usedInsightCollectionPage);
 	}
-	
+
 	@Test
 	public void mailFoldertest() {
 		//GET me/mailFolders
@@ -172,7 +173,7 @@ public class UserTests {
 			assertNotNull(messageCollectionPage);
 		}
 	}
-	
+
 	@Test
 	public void meMemberof() {
 		IDirectoryObjectCollectionWithReferencesPage page = graphServiceClient.me().memberOf().buildRequest().get();
@@ -201,7 +202,7 @@ public class UserTests {
 	}
 
 	@Test
-	public void emptyPostContentType() {
+	public void emptyPostContentTypeIsNotReset() {
 		final String contentTypeValue = "application/json";
 		final HeaderOption ctype = new HeaderOption("Content-Type", contentTypeValue);
         final ArrayList<Option> options = new ArrayList<>();
@@ -211,7 +212,16 @@ public class UserTests {
                                             .buildRequest(options)
                                             .withHttpMethod(HttpMethod.POST)
                                             .getHttpRequest();
-		assertEquals(contentTypeValue, request.body().contentType().toString());					
+		assertEquals(contentTypeValue, request.body().contentType().toString());
+	}
+    @Test
+	public void emptyPostContentTypeIsNotSet() {
+        final Request request = graphServiceClient.me()
+                                            .revokeSignInSessions()
+                                            .buildRequest()
+                                            .withHttpMethod(HttpMethod.POST)
+                                            .getHttpRequest();
+		assertNull(request.body().contentType());
 	}
 	@Test
 	public void castTest() {

--- a/src/test/java/com/microsoft/graph/serializer/EdmNativeTypeSerializerTests.java
+++ b/src/test/java/com/microsoft/graph/serializer/EdmNativeTypeSerializerTests.java
@@ -1,0 +1,76 @@
+package com.microsoft.graph.serializer;
+
+import static org.junit.Assert.assertEquals;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import com.microsoft.graph.logger.DefaultLogger;
+
+import org.junit.Test;
+
+public class EdmNativeTypeSerializerTests {
+    @Test
+    public void testBoolean() throws Exception {
+        final DefaultSerializer serializer = new DefaultSerializer(new DefaultLogger());
+
+        final String source = "{\"@odata.context\":\"https://graph.microsoft.com/v1.0/$metadata#Edm.Null\",\"@odata.null\":true}";
+        final Boolean result = serializer.deserializeObject(source, Boolean.class);
+
+        assertEquals(Boolean.valueOf(true), result);
+    }
+    @Test
+    public void testInteger() throws Exception {
+        final DefaultSerializer serializer = new DefaultSerializer(new DefaultLogger());
+
+        final String source = "{\"@odata.context\":\"https://graph.microsoft.com/v1.0/$metadata#Edm.Null\",\"@odata.null\":12}";
+        final Integer result = serializer.deserializeObject(source, Integer.class);
+
+        assertEquals(Integer.valueOf(12), result);
+    }
+    @Test
+    public void testString() throws Exception {
+        final DefaultSerializer serializer = new DefaultSerializer(new DefaultLogger());
+
+        final String source = "{\"@odata.context\":\"https://graph.microsoft.com/v1.0/$metadata#Edm.Null\",\"@odata.null\":\"toto\"}";
+        final String result = serializer.deserializeObject(source, String.class);
+
+        assertEquals("toto", result);
+    }
+    @Test
+    public void testFloat() throws Exception {
+        final DefaultSerializer serializer = new DefaultSerializer(new DefaultLogger());
+
+        final String source = "{\"@odata.context\":\"https://graph.microsoft.com/v1.0/$metadata#Edm.Null\",\"@odata.null\":12.5}";
+        final Float result = serializer.deserializeObject(source, Float.class);
+
+        assertEquals(Float.valueOf("12.5"), result);
+    }
+    @Test
+    public void testLong() throws Exception {
+        final DefaultSerializer serializer = new DefaultSerializer(new DefaultLogger());
+
+        final String source = "{\"@odata.context\":\"https://graph.microsoft.com/v1.0/$metadata#Edm.Null\",\"@odata.null\":12}";
+        final Long result = serializer.deserializeObject(source, Long.class);
+
+        assertEquals(Long.valueOf(12), result);
+    }
+    @Test
+    public void testBigDecimal() throws Exception {
+        final DefaultSerializer serializer = new DefaultSerializer(new DefaultLogger());
+
+        final String source = "{\"@odata.context\":\"https://graph.microsoft.com/v1.0/$metadata#Edm.Null\",\"@odata.null\":12}";
+        final BigDecimal result = serializer.deserializeObject(source, BigDecimal.class);
+
+        assertEquals(BigDecimal.valueOf(12), result);
+    }
+    @Test
+    public void testUUID() throws Exception {
+        final DefaultSerializer serializer = new DefaultSerializer(new DefaultLogger());
+
+        final String source = "{\"@odata.context\":\"https://graph.microsoft.com/v1.0/$metadata#Edm.Null\",\"@odata.null\":\"0E6558C3-9640-4385-860A-2A894AC5C246\"}";
+        final UUID result = serializer.deserializeObject(source, UUID.class);
+
+        assertEquals(UUID.fromString("0E6558C3-9640-4385-860A-2A894AC5C246"), result);
+    }
+}


### PR DESCRIPTION
- adds a serializer to handle actions & functions with primitive return types
- fixes a bug where null content on post request would have a wrong application/octet-stream content type

fixes #687