### PR TITLE
bugfix/ODSP path encoding

### DIFF
--- a/src/main/java/com/microsoft/graph/requests/DriveItemRequestBuilder.java
+++ b/src/main/java/com/microsoft/graph/requests/DriveItemRequestBuilder.java
@@ -93,7 +93,14 @@ public class DriveItemRequestBuilder extends BaseRequestBuilder<DriveItem> {
      */
     @Nonnull
     public DriveItemRequestBuilder itemWithPath(@Nonnull final String path) {
-        return new DriveItemRequestBuilder(getRequestUrl() + ":/" + path + ":", getClient(), null);
+        String value = path;
+        try {
+            value = java.net.URLEncoder.encode(path, java.nio.charset.StandardCharsets.UTF_8.toString()).replace("+", "%20");
+            //ODSP doesn't respect application/x-www-form-urlencoded MIME format and expects spaces with %20
+        } catch (java.io.UnsupportedEncodingException ex) {
+            throw new ClientException("unsupported encoding", ex);
+        }
+        return new DriveItemRequestBuilder(getRequestUrl() + ":/" + value + ":", getClient(), null);
     }
 
 


### PR DESCRIPTION
- adds a unit test to validate onedrive path encoding
- code-gen: ODSP path encoding

related https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/issues/516