### PR TITLE
- adds worfkow dispatch trigger to codeQL and api level lint

### DIFF
--- a/.github/workflows/api-level-lint.yml
+++ b/.github/workflows/api-level-lint.yml
@@ -1,6 +1,7 @@
 name: "Checks the SDK only using APIs from the targeted API level"
 
 on: 
+  workflow_dispatch:
   push:
     branches:
       - dev

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,6 +1,7 @@
 name: "CodeQL"
 
 on:
+  workflow_dispatch:
   push:
     branches: [dev, master]
   pull_request:


### PR DESCRIPTION
generation PRs don't trigger the worfklows anymore as they are created by a bot (and actions don't trigger when the trigger was started by a bot).
This PR adds the ability to manually trigger the actions.

We could, in a subsequent PR, add steps in the generation pipeline to trigger the actions "manually". https://github.com/marketplace/actions/workflow-dispatch