### PR TITLE
Update proguard-rules.txt

### DIFF
--- a/docs/proguard-rules.txt
+++ b/docs/proguard-rules.txt
@@ -1,4 +1,5 @@
--keep class com.microsoft.** { *; }
+# Keep the names of JSON-serializable objects.
+-keepnames public class * implements com.microsoft.graph.serializer.IJsonBackedObject
 
 ## GSON 2.2.4 specific rules ##
 # Source: https://github.com/google/gson/blob/master/examples/android-proguard-example/proguard.cfg


### PR DESCRIPTION
```-keep class com.microsoft.** { *; }``` keeps too much. I added a new rule that keeps the names of the JSON-backed classes.

<!-- Read me before you submit this pull request

First off, thank you for opening this pull request! We do appreciate it.

The requests and models for this client library are generated. We won't be accepting pull requests for those code files. With that said, we do appreciate
it when you open pull requests with the proposed file changes, as we'll use that to help guide us in updating our template files.

-->

<!-- Optional. Set the issues that this pull request fixes. Delete 'Fixes #' if there isn't an issue associated with this pull request. -->
Fixes #1014 

<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request
- The current Proguard keep rule ```-keep class com.microsoft.** { *; }``` is keeping too much. By keeping just the names of JSON-serializable objects, I was able to reduce the size of the resulting APK by about 600 kb.

<!-- Optional. Provide related links. This might be other pull requests, code files, StackOverflow posts. Delete this section if it is not used. -->
### Other links
#258 

<!-- Is this PR adding a new hand crafted extension class? If so, please update $filesThatShouldNotBeDeleted variable in .azure-pipelines/generate-v1.0-models.yml file, so that it doesn't get deleted by auto generation pipeline.-->
- Other notes: Ideally these rules would be included in a "consumer-rules.pro" that gets automatically pulled in by the Android build process. I didn't propose one here because it would affect existing users, so those rules would have to be solidly vetted and ideally part of an automated test suite before being put into place.
