### PR TITLE
chore: update branch protection rules

### DIFF
--- a/.github/policies/msgraph-sdk-java-branch-protection.yml
+++ b/.github/policies/msgraph-sdk-java-branch-protection.yml
@@ -30,17 +30,17 @@ configuration:
     # Are commits required to be signed. boolean. TODO: all contributors must have commit signing on local machines.
     requiresCommitSignatures: false
     # Are conversations required to be resolved before merging? boolean
-    requiresConversationResolution: false
+    requiresConversationResolution: true
     # Are merge commits prohibited from being pushed to this branch. boolean
     requiresLinearHistory: false
     # Required status checks to pass before merging. Values can be any string, but if the value does not correspond to any existing status check, the status check will be stuck on pending for status since nothing exists to push an actual status
     requiredStatusChecks:
-    - CodeQL
+    - Analyze (java)
     - lint-api-level
     - license/cla
     - build
     # Require branches to be up to date before merging. Requires requiredStatusChecks. boolean
-    requiresStrictStatusChecks: false
+    requiresStrictStatusChecks: true
     # Indicates whether there are restrictions on who can push. boolean. Should be set with whoCanPush.
     restrictsPushes: false
     # Restrict who can dismiss pull request reviews. boolean
@@ -67,17 +67,17 @@ configuration:
     # Are commits required to be signed. boolean. TODO: all contributors must have commit signing on local machines.
     requiresCommitSignatures: false
     # Are conversations required to be resolved before merging? boolean
-    requiresConversationResolution: false
+    requiresConversationResolution: true
     # Are merge commits prohibited from being pushed to this branch. boolean
     requiresLinearHistory: false
     # Required status checks to pass before merging. Values can be any string, but if the value does not correspond to any existing status check, the status check will be stuck on pending for status since nothing exists to push an actual status
     requiredStatusChecks:
-    - CodeQL
+    - Analyze (java)
     - lint-api-level
     - license/cla
     - build
     # Require branches to be up to date before merging. Requires requiredStatusChecks. boolean
-    requiresStrictStatusChecks: false
+    requiresStrictStatusChecks: true
     # Indicates whether there are restrictions on who can push. boolean. Should be set with whoCanPush.
     restrictsPushes: false
     # Restrict who can dismiss pull request reviews. boolean


### PR DESCRIPTION
* All dev and main branches must have policy
* Require status checks to pass before merging
* Require code owner approvals of all changes in main/master and dev branches
* Require re-approval after new commits

> **Note**: We must validate this PR after merge by opening another PR to make sure that the required status checks run as expected so that we don't introduce misconfigured blocking policy.