### PR TITLE
Use parent Call.Factory of OkHttpClient to be able to use OpenTelemetry

### DIFF
--- a/src/main/java/com/microsoft/graph/requests/GraphServiceClient.java
+++ b/src/main/java/com/microsoft/graph/requests/GraphServiceClient.java
@@ -18,6 +18,7 @@ import com.microsoft.graph.http.IHttpProvider;
 import com.microsoft.graph.authentication.IAuthenticationProvider;
 import com.microsoft.graph.logger.ILogger;
 import com.microsoft.graph.serializer.ISerializer;
+import okhttp3.Call;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 
@@ -63,14 +64,14 @@ public class GraphServiceClient<nativeRequestType> extends BaseClient<nativeRequ
      * @return builder to start configuring the client
      */
     @Nonnull
-    public static <nativeClient, nativeRequest> Builder<nativeClient, nativeRequest> builder(@Nonnull final Class<nativeClient> nativeClientClass, @Nonnull final Class<nativeRequest> nativeRequestClass) {
+    public static <nativeClient extends Call.Factory, nativeRequest> Builder<nativeClient, nativeRequest> builder(@Nonnull final Class<nativeClient> nativeClientClass, @Nonnull final Class<nativeRequest> nativeRequestClass) {
         return new Builder<>();
     }
     /**
      * Builder to help configure the Graph service client
      * @param <nativeRequestType> type of a request for the native http client
      */
-    public static class Builder<httpClientType, nativeRequestType> extends BaseClient.Builder<httpClientType, nativeRequestType> {
+    public static class Builder<httpClientType extends Call.Factory, nativeRequestType> extends BaseClient.Builder<httpClientType, nativeRequestType> {
         /**
          * Sets the serializer.
          *


### PR DESCRIPTION
See https://github.com/microsoftgraph/msgraph-sdk-java-core/pull/1252
This change depends on that change.

----

For application insights it is good to be able to get insights in all incoming and outgoing requests.
OpenTelemetry is the standard for that.

I tried to use https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/okhttp/okhttp-3.0/library/README.md

```java

  private Call.Factory createTracedClient(OpenTelemetry openTelemetry, @Nonnull final IAuthenticationProvider auth) {
        return OkHttpTelemetry.builder(openTelemetry).build().newCallFactory(createClient(auth));
    }

  private OkHttpClient createClient(@Nonnull final IAuthenticationProvider auth) {
        return HttpClients.createDefault(auth);
    }

// then create the GraphServiceClient
IAuthenticationProvider authenticationProvider = requestUrl -> cf;
GraphServiceClient
                .builder(Call.Factory.class, Request.class)
                .httpClient(createTracedClient(openTelemetry, authenticationProvider))
                .authenticationProvider(authenticationProvider)
                .buildClient();


```

This gives an exception at runtime

```
Caused by: java.lang.ClassCastException: class io.opentelemetry.instrumentation.okhttp.v3_0.TracingCallFactory cannot be cast to class okhttp3.OkHttpClient (io.opentelemetry.instrumentation.okhttp.v3_0.TracingCallFactory and okhttp3.OkHttpClient are in unnamed module of loader io.quarkus.bootstrap.classloading.QuarkusClassLoader @4df50bcc)
        at com.microsoft.graph.core.BaseClient$Builder.getHttpProvider(BaseClient.java:188)
        at com.microsoft.graph.core.BaseClient$Builder.buildClient(BaseClient.java:275)
        at com.microsoft.graph.requests.GraphServiceClient$Builder.buildClient(GraphServiceClient.java:153)
```

But there is no actual use of casting it to OkHttpClient, only the methods of Call.Factory are used.

As that is the minimal base required, I changed the code as well that in the generic it requires as least Call.Factory as base.