### PR TITLE
Bumps Graph Core dependency version and update lib version for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [6.2.1] - 2024-02-16
+
+### Changed
+
+- Bumps microsoft-graph-core dependency to 3.1.3
+
 ## [6.2.0] - 2024-02-14
 
 - Weekly Generated v1.0 models and request builders using Kiota.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ repositories {
 
 dependencies {
     // Include the sdk as a dependency
-    implementation 'com.microsoft.graph:microsoft-graph:6.2.0'
+    implementation 'com.microsoft.graph:microsoft-graph:6.2.1'
     // Uncomment the line below if you are building an android application
     //implementation 'com.google.guava:guava:30.1.1-android'
     // This dependency is only needed if you are using a TokenCredential object for authentication
@@ -37,7 +37,7 @@ Add the dependency in `dependencies` in pom.xml
   <!-- Include the sdk as a dependency -->
   <groupId>com.microsoft.graph</groupId>
   <artifactId>microsoft-graph</artifactId>
-  <version>6.2.0</version>
+  <version>6.2.1</version>
 </dependency>
 <dependency>
   <!-- This dependency is only needed if you are using a TokenCredential object for authentication -->

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,7 +27,7 @@ mavenGroupId         = com.microsoft.graph
 mavenArtifactId      = microsoft-graph
 mavenMajorVersion = 6
 mavenMinorVersion = 2
-mavenPatchVersion = 0
+mavenPatchVersion = 1
 mavenArtifactSuffix =
 
 #These values are used to run functional tests

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -5,12 +5,12 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.2'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.10.2'
     testImplementation 'org.mockito:mockito-inline:5.2.0'
-    
+
     implementation 'com.squareup.okhttp3:okhttp:4.12.0'
     implementation 'jakarta.annotation:jakarta.annotation-api:2.1.1'
 
-    // Core Http library 
-    api 'com.microsoft.graph:microsoft-graph-core:3.1.2'
+    // Core Http library
+    api 'com.microsoft.graph:microsoft-graph-core:3.1.3'
     implementation 'com.microsoft.kiota:microsoft-kiota-authentication-azure:1.0.2'
     implementation 'com.microsoft.kiota:microsoft-kiota-http-okHttp:1.0.2'
     implementation 'com.microsoft.kiota:microsoft-kiota-serialization-json:1.0.2'

--- a/src/main/java/com/microsoft/graph/info/Constants.java
+++ b/src/main/java/com/microsoft/graph/info/Constants.java
@@ -3,6 +3,6 @@ package com.microsoft.graph.info;
 /** Multi-purpose constants holder used accross the SDK */
 public final class Constants {
     /** The SDK version */
-    public static final String VERSION_NAME = "6.2.0";
+    public static final String VERSION_NAME = "6.2.1";
 }
 


### PR DESCRIPTION
Graph Core `3.1.3` contains the error deserialization bug fix to unblock customers.