### PR TITLE
working elsewhere is been identified as 0 not 4!

### DIFF
--- a/src/main/java/com/microsoft/graph/generated/models/ScheduleInformation.java
+++ b/src/main/java/com/microsoft/graph/generated/models/ScheduleInformation.java
@@ -48,7 +48,7 @@ public class ScheduleInformation implements AdditionalDataHolder, BackedModel, P
         return value;
     }
     /**
-     * Gets the availabilityView property value. Represents a merged view of availability of all the items in scheduleItems. The view consists of time slots. Availability during each time slot is indicated with: 0= free, 1= tentative, 2= busy, 3= out of office, 4= working elsewhere.
+     * Gets the availabilityView property value. Represents a merged view of availability of all the items in scheduleItems. The view consists of time slots. Availability during each time slot is indicated with: 0= free, 1= tentative, 2= busy, 3= out of office, 0= working elsewhere.
      * @return a {@link String}
      */
     @jakarta.annotation.Nullable


### PR DESCRIPTION
<!-- Read me before you submit this pull request

First off, thank you for opening this pull request! We do appreciate it.

The requests and models for this client library are generated. We won't be accepting pull requests for those code files. With that said, we do appreciate
it when you open pull requests with the proposed file changes, as we'll use that to help guide us in updating our template files.

-->

<!-- Optional. Set the issues that this pull request fixes. Delete 'Fixes #' if there isn't an issue associated with this pull request. -->
Fixes : The description is off

<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request
- I do not know, whether it is intentionally or a bug, but if one requests getschedule an appointmeint "shownAs" as "working elsewhere" is represented with a zero, not 4.

<!-- Optional. Provide related links. This might be other pull requests, code files, StackOverflow posts. Delete this section if it is not used. -->
### Other links

<!-- Is this PR adding a new hand crafted extension class? If so, please update $filesThatShouldNotBeDeleted variable in .azure-pipelines/generate-v1.0-models.yml file, so that it doesn't get deleted by auto generation pipeline.-->
-
