### PR TITLE
Fix branch name to download previous release artifacts from

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -67,12 +67,16 @@ jobs:
         with:
           name: drop
           path: artifacts/current/
+      - name: Get latest release tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: echo "BRANCH=$(gh release list -L 1 --json tagName --jq '.[0] | .tagName')" >> $GITHUB_ENV
       - name: Download Last Successful Build
         uses: dawidd6/action-download-artifact@v3.1.4
         with:
           workflow: preview-and-release.yml
           workflow_conclusion: success
-          branch: main
+          branch: ${{ env.BRANCH }}
           event: push
           name: drop
           path: artifacts/previous/


### PR DESCRIPTION
This PR:
- Fixes failing `compare-packages` checks in https://github.com/microsoftgraph/msgraph-sdk-java/pull/2022

Context:
- Release workflow was [updated ](https://github.com/microsoftgraph/msgraph-sdk-java/blob/main/.github/workflows/preview-and-release.yml#L57)to upload build artifacts to workflow runs only when a tag is created by release-please.
- This changes `download-artifact` to use the latest successful run by fetching the latest tag name using GitHub CLI