### PR TITLE
Fix bug in triggering maven central release workflow

### DIFF
--- a/.github/workflows/preview-and-release.yml
+++ b/.github/workflows/preview-and-release.yml
@@ -54,7 +54,7 @@ jobs:
         run: ./gradlew $PREVIEW_TASK
 
   maven_Release:
-    if: startsWith(github.ref, 'refs/tags/') && ${{ github.actor == 'release-please[bot]' }}
+    if: ${{ startsWith(github.ref, 'refs/tags/') && github.actor == 'release-please[bot]'}}
     environment:
       name: maven_central_release
     runs-on: ubuntu-latest


### PR DESCRIPTION
Attempts to trigger Maven central release are now being triggered by PRs instead of tags by release-please e.g. https://github.com/microsoftgraph/msgraph-sdk-java/actions/runs/9361922743

Bug seems to have been introduced by https://github.com/microsoftgraph/msgraph-sdk-java/pull/2025