### PR TITLE
ci: adds missing gradle dependencies caching to CI

### DIFF
--- a/.github/workflows/api-level-lint.yml
+++ b/.github/workflows/api-level-lint.yml
@@ -16,6 +16,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 21
+          cache: gradle
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3.2.1
       - name: Add execution right to the script

--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -57,6 +57,7 @@ jobs:
         with:
           java-version: 8
           distribution: 'temurin'
+          cache: gradle
       - name: Grant Execute permission for gradlew
         run: chmod +x gradlew
       - name: Build with Java 8


### PR DESCRIPTION
related https://www.sonatype.com/blog/maven-central-and-the-tragedy-of-the-commons