### PR TITLE
Limit API surface validation to generated files

### DIFF
--- a/.github/workflows/validate-public-api-surface.yml
+++ b/.github/workflows/validate-public-api-surface.yml
@@ -5,6 +5,8 @@ on:
   push:
   pull_request:
     branches: [ 'main' ]
+    paths:
+      - 'src/**/generated/**'
 
 permissions:
   contents: read


### PR DESCRIPTION
Minor tweak to remove validation comments etc from PRs that don't need the checks e.g. [release PR](https://github.com/microsoftgraph/msgraph-sdk-java/pull/2181#issuecomment-2387773439)