### PR TITLE
fix: resolve javadoc and source locations

### DIFF
--- a/.github/workflows/api-level-lint.yml
+++ b/.github/workflows/api-level-lint.yml
@@ -17,6 +17,9 @@ jobs:
           distribution: 'temurin'
           java-version: 21
           cache: gradle
+      - name: Move generated sources to correct package
+        run: .\scripts\copyFilesOnBuild.ps1 -inputPath '.\src\main\java\com\microsoft\graph\generated'
+        shell: pwsh
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3.2.2
       - name: Add execution right to the script

--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -22,6 +22,9 @@ jobs:
         run: |
           pip install detect-secrets
           git ls-files -z | xargs -0 detect-secrets-hook --baseline .secrets.baseline
+      - name: Move generated sources to correct package
+        run: .\scripts\copyFilesOnBuild.ps1 -inputPath '.\src\main\java\com\microsoft\graph\generated'
+        shell: pwsh
       - name: Grant Execute permission for gradlew
         run: chmod +x gradlew
       - name: Build with Gradle
@@ -60,6 +63,9 @@ jobs:
           java-version: 8
           distribution: 'temurin'
           cache: gradle
+      - name: Move generated sources to correct package
+        run: .\scripts\copyFilesOnBuild.ps1 -inputPath '.\src\main\java\com\microsoft\graph\generated'
+        shell: pwsh
       - name: Grant Execute permission for gradlew
         run: chmod +x gradlew
       - name: Build with Java 8

--- a/.github/workflows/preview-and-release.yml
+++ b/.github/workflows/preview-and-release.yml
@@ -37,6 +37,9 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRIBUTION}}
           cache: gradle
+      - name: Move generated sources to correct package
+        run: .\scripts\copyFilesOnBuild.ps1 -inputPath '.\src\main\java\com\microsoft\graph\generated'
+        shell: pwsh
       - name: Detect secrets
         run: |
           pip install detect-secrets
@@ -76,6 +79,9 @@ jobs:
         run: |
           pip install detect-secrets
           git ls-files -z | xargs -0 detect-secrets-hook --baseline .secrets.baseline
+      - name: Move generated sources to correct package
+        run: .\scripts\copyFilesOnBuild.ps1 -inputPath '.\src\main\java\com\microsoft\graph\generated'
+        shell: pwsh
       - name: Download File
         run: .\scripts\decodeAndWrite.ps1 -encodedValue $env:ENCODED_VALUE -outputPath $env:OUTPUT_PATH
         shell: pwsh
@@ -129,6 +135,9 @@ jobs:
         java-version: ${{ env.JAVA_VERSION }}
         distribution: ${{ env.JAVA_DISTRIBUTION}}
         cache: gradle
+    - name: Move generated sources to correct package
+      run: .\scripts\copyFilesOnBuild.ps1 -inputPath '.\src\main\java\com\microsoft\graph\generated'
+      shell: pwsh
     - name: Download file
       run: .\scripts\decodeAndWrite.ps1 -encodedValue $env:ENCODED_VALUE -outputPath $env:OUTPUT_PATH
       shell: pwsh

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ def pomConfig = {
 }
 
 tasks.withType(Javadoc).configureEach {
-    enabled = false
+    enabled = true
     options.addStringOption('Xdoclint:-missing', '-quiet')
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,10 @@ def pomConfig = {
     }
 }
 
-tasks.withType(Javadoc).all { enabled = false }
+tasks.withType(Javadoc).configureEach {
+    enabled = false
+    options.addStringOption('Xdoclint:-missing', '-quiet')
+}
 
 
 tasks.jar {

--- a/scripts/copyFilesOnBuild.ps1
+++ b/scripts/copyFilesOnBuild.ps1
@@ -1,0 +1,30 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+<# 
+.Synopsis
+    Copy files to a new location that is the parent of the current directory. 
+.Description 
+    Receives an encoded string value and decodes it using base64. 
+    Write the new decoded string to a local file for later consumption. 
+.Parameter inputPath
+    The encoded string we wish to decode.  
+#>
+
+Param(
+    [Parameter(Mandatory = $true)][string]$inputPath 
+)
+
+$fullPath = (Get-Item $inputPath).FullName
+$parentDirectory = (Get-Item $inputPath).Parent
+Push-Location $inputPath
+
+Get-ChildItem '*' -Filter *.java -recurse | ForEach-Object {
+    $TargetDirectory = $_.DirectoryName.Replace($fullPath, "")
+    $TargetPath = Join-Path -Path $parentDirectory -ChildPath $TargetDirectory 
+    If (!(Test-Path $TargetPath)) {
+        New-Item -Path $TargetPath -Type Directory -Force | out-null
+    }
+    $_ | Move-Item -Destination $TargetPath -Force
+}
+Pop-Location


### PR DESCRIPTION
fixes https://github.com/microsoftgraph/msgraph-sdk-java/issues/2078
fixes https://github.com/microsoftgraph/msgraph-sdk-java/issues/1893

This PR includes the following changes.
- enables the javadoc task to ensure that javadocs are part of release task artifacts
- adds a step in CI/CD stages to move sources in the `/generated` folder up one folder so that the generated sources are in the correct package structure

Considerations.
As much as updating the generation pipeline to place the generated files in the correct package structure is a good idea, we have a number of hand writter files in the root path such as https://github.com/microsoftgraph/msgraph-sdk-java/pull/2298 that would be overwritten or replaced. The alternative would involve keeping a record of handwritten files and moving them just in time but that would increase the maintenance burden. 