### PR TITLE
Added new constructor for GraphServiceClient

### DIFF
--- a/src/main/java/com/microsoft/graph/serviceclient/GraphServiceClient.java
+++ b/src/main/java/com/microsoft/graph/serviceclient/GraphServiceClient.java
@@ -57,7 +57,7 @@ public class GraphServiceClient extends BaseGraphServiceClient implements IBaseC
      * @param clouds The Clouds for the GraphServiceClient.
      *
      */
-    public GraphServiceClient(@Nonnull AuthenticationProvider authenticationProvider,@Nonnull OkHttpClient client, @Nonnull Clouds clouds) {
+    public GraphServiceClient(@Nonnull AuthenticationProvider authenticationProvider, @Nonnull OkHttpClient client, @Nonnull Clouds clouds) {
         this(new BaseGraphRequestAdapter(authenticationProvider, clouds, "v1.0", getGraphClientOptions()));
     }
     /**

--- a/src/main/java/com/microsoft/graph/serviceclient/GraphServiceClient.java
+++ b/src/main/java/com/microsoft/graph/serviceclient/GraphServiceClient.java
@@ -53,14 +53,14 @@ public class GraphServiceClient extends BaseGraphServiceClient implements IBaseC
     }
     /**
      * Instantiate the GraphServiceClient using an AuthenticationProvider, Cloud and OkHttpClient.
+     * @param authenticationProvider The AuthenticationProvider for this GraphServiceClient.
      * @param client The OkHttpClient for the GraphServiceClient.
      * @param clouds The Clouds for the GraphServiceClient.
-     * @param authenticationProvider The AuthenticationProvider for this GraphServiceClient.
      *
      */
     @SuppressWarnings("LambdaLast")
-    public GraphServiceClient(@Nonnull OkHttpClient client, @Nonnull Clouds clouds, @Nonnull AuthenticationProvider authenticationProvider) {
-        this(new BaseGraphRequestAdapter(authenticationProvider, clouds, "v1.0", getGraphClientOptions()));
+    public GraphServiceClient(@Nonnull AuthenticationProvider authenticationProvider, @Nonnull OkHttpClient client, @Nonnull Clouds clouds) {
+        this(new BaseGraphRequestAdapter(authenticationProvider, clouds, "v1.0", client));
     }
     /**
      * Instantiate the GraphServiceClient using an AuthenticationProvider and OkHttpClient.

--- a/src/main/java/com/microsoft/graph/serviceclient/GraphServiceClient.java
+++ b/src/main/java/com/microsoft/graph/serviceclient/GraphServiceClient.java
@@ -51,6 +51,16 @@ public class GraphServiceClient extends BaseGraphServiceClient implements IBaseC
         this(new BaseGraphRequestAdapter(authenticationProvider, null, "v1.0" , getGraphClientOptions()));
     }
     /**
+     * Instantiate the GraphServiceClient using an AuthenticationProvider, baseUrl and OkHttpClient.
+     * @param authenticationProvider The AuthenticationProvider for this GraphServiceClient.
+     * @param client The OkHttpClient for the GraphServiceClient.
+     * @param clouds The Clouds for the GraphServiceClient.
+     *
+     */
+    public GraphServiceClient(@Nonnull AuthenticationProvider authenticationProvider,@Nonnull OkHttpClient client, @Nonnull Clouds clouds) {
+        this(new BaseGraphRequestAdapter(authenticationProvider, clouds, "v1.0", getGraphClientOptions()));
+    }
+    /**
      * Instantiate the GraphServiceClient using an AuthenticationProvider and OkHttpClient.
      * @param authenticationProvider The AuthenticationProvider for this GraphServiceClient.
      * @param client The OkHttpClient for the GraphServiceClient.

--- a/src/main/java/com/microsoft/graph/serviceclient/GraphServiceClient.java
+++ b/src/main/java/com/microsoft/graph/serviceclient/GraphServiceClient.java
@@ -52,13 +52,14 @@ public class GraphServiceClient extends BaseGraphServiceClient implements IBaseC
         this(new BaseGraphRequestAdapter(authenticationProvider, null, "v1.0" , getGraphClientOptions()));
     }
     /**
-     * Instantiate the GraphServiceClient using an AuthenticationProvider, baseUrl and OkHttpClient.
-     * @param authenticationProvider The AuthenticationProvider for this GraphServiceClient.
+     * Instantiate the GraphServiceClient using an AuthenticationProvider, Cloud and OkHttpClient.
      * @param client The OkHttpClient for the GraphServiceClient.
      * @param clouds The Clouds for the GraphServiceClient.
+     * @param authenticationProvider The AuthenticationProvider for this GraphServiceClient.
      *
      */
-    public GraphServiceClient(@Nonnull AuthenticationProvider authenticationProvider, @Nonnull OkHttpClient client, @Nonnull Clouds clouds) {
+    @SuppressWarnings("LambdaLast")
+    public GraphServiceClient(@Nonnull OkHttpClient client, @Nonnull Clouds clouds, @Nonnull AuthenticationProvider authenticationProvider) {
         this(new BaseGraphRequestAdapter(authenticationProvider, clouds, "v1.0", getGraphClientOptions()));
     }
     /**

--- a/src/main/java/com/microsoft/graph/serviceclient/GraphServiceClient.java
+++ b/src/main/java/com/microsoft/graph/serviceclient/GraphServiceClient.java
@@ -2,6 +2,7 @@ package com.microsoft.graph.serviceclient;
 
 import com.microsoft.graph.core.CoreConstants;
 import com.microsoft.graph.core.requests.BaseGraphRequestAdapter;
+import com.microsoft.graph.core.requests.BaseGraphRequestAdapter.Clouds;
 import com.microsoft.graph.core.requests.BatchRequestBuilder;
 import com.microsoft.graph.core.requests.options.GraphClientOption;
 import com.microsoft.graph.core.requests.IBaseClient;


### PR DESCRIPTION
fixes https://github.com/microsoftgraph/msgraph-sdk-java/issues/2354



Fixes [#]2354(https://github.com/microsoftgraph/msgraph-sdk-java/issues/2354)


-Allows Us to Overide the default Base URL in use cases such as GCC customers 
