### PR TITLE
chore: add release-please gha

### DIFF
--- a/.github/workflows/release-please-gha.yml
+++ b/.github/workflows/release-please-gha.yml
@@ -1,0 +1,34 @@
+## -----------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+## -----------------------------------------------------------------------------
+#
+# Summary:
+# This GitHub Actions workflow automates the release process using Release Please.
+# It triggers on pushes to the main branch, generates a GitHub App token using organization
+# variables and secrets, and then runs the release-please-action to manage versioning and changelogs.
+
+name: Release Please
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.RELEASE_PLEASE_TOKEN_PROVIDER_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_TOKEN_PROVIDER_PEM }}
+          
+      - name: Release Please
+        uses: googleapis/release-please-action@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
The Release-Please GitHub app was retired this week. Adding this so we don't have to manage PATs.

