### PR TITLE
fix: remove previewBranch parameter and align deploy stage condition

### DIFF
--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -11,11 +11,6 @@ trigger:
     include:
       - main
 
-parameters:
-  - name: previewBranch
-    type: string
-    default: "refs/heads/main"
-
 resources:
   repositories:
     - repository: 1ESPipelineTemplates
@@ -112,7 +107,7 @@ extends:
                   targetPath: "$(PACKAGE_PATH)"
 
       - stage: deploy
-        condition: and(or(contains(variables['build.sourceBranch'], 'refs/tags/v'), eq(variables['build.sourceBranch'], '${{ parameters.previewBranch }}')), succeeded())
+        condition: and(contains(variables['build.sourceBranch'], 'refs/tags/v'), succeeded())
         dependsOn: build
         jobs:
           - deployment: deploy_maven


### PR DESCRIPTION
The deploy stage condition referenced a `previewBranch` parameter that became unnecessary after removing `deploy_github`. This caused the deploy stage to execute on `previewBranch` pushes while immediately skipping all jobs — confusing and misleading.

## Changes

- **Removed `previewBranch` parameter** — no longer referenced anywhere in the pipeline
- **Simplified deploy stage condition** — now matches the `deploy_maven` job's condition exactly:
  ```yaml
  # Before
  condition: and(or(contains(variables['build.sourceBranch'], 'refs/tags/v'), eq(variables['build.sourceBranch'], '${{ parameters.previewBranch }}')), succeeded())

  # After
  condition: and(contains(variables['build.sourceBranch'], 'refs/tags/v'), succeeded())
  ```