### PR TITLE
chore(deps): consolidate dependabot dependency updates

### DIFF
--- a/.github/workflows/api-level-lint.yml
+++ b/.github/workflows/api-level-lint.yml
@@ -31,7 +31,7 @@ jobs:
         working-directory: ./android
       - name: Upload linting results
         if: failure() && steps.lint.outcome == 'failure'
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: lint-report
           path: ./android/build/reports

--- a/.github/workflows/api-level-lint.yml
+++ b/.github/workflows/api-level-lint.yml
@@ -21,7 +21,7 @@ jobs:
         run: .\scripts\copyFilesOnBuild.ps1 -inputPath '.\src\main\java\com\microsoft\graph\generated'
         shell: pwsh
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v3.2.2
+        uses: android-actions/setup-android@v4.0.1
       - name: Add execution right to the script
         run: chmod +x gradlew
         working-directory: ./android

--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2.4.0
+        uses: dependabot/fetch-metadata@v3.0.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -27,14 +27,14 @@ jobs:
         run: ./gradlew build
       - name: Upload Unit Test Results
         if: ${{ always() }}
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: UnitTests
           path: |
             build/reports/tests/test/**
             build/test-results/**
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: drop
           path: |

--- a/.github/workflows/validate-public-api-surface.yml
+++ b/.github/workflows/validate-public-api-surface.yml
@@ -35,14 +35,14 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload patch file as artifact
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         continue-on-error: true
         with:
           name: patch
           path: '*.patch'
       - name: Upload explanations file as artifact
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         continue-on-error: true
         with:
           name: explanations

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -6,10 +6,10 @@ dependencies {
     // Core Http library
     api 'com.microsoft.graph:microsoft-graph-core:3.6.5'
 
-    implementation 'com.microsoft.kiota:microsoft-kiota-authentication-azure:1.9.0'
-    implementation 'com.microsoft.kiota:microsoft-kiota-http-okHttp:1.9.0'
-    implementation 'com.microsoft.kiota:microsoft-kiota-serialization-json:1.9.0'
-    implementation 'com.microsoft.kiota:microsoft-kiota-serialization-text:1.9.0'
-    implementation 'com.microsoft.kiota:microsoft-kiota-serialization-form:1.9.0'
-    implementation 'com.microsoft.kiota:microsoft-kiota-serialization-multipart:1.9.0'
+    implementation 'com.microsoft.kiota:microsoft-kiota-authentication-azure:1.9.2'
+    implementation 'com.microsoft.kiota:microsoft-kiota-http-okHttp:1.9.2'
+    implementation 'com.microsoft.kiota:microsoft-kiota-serialization-json:1.9.2'
+    implementation 'com.microsoft.kiota:microsoft-kiota-serialization-text:1.9.2'
+    implementation 'com.microsoft.kiota:microsoft-kiota-serialization-form:1.9.2'
+    implementation 'com.microsoft.kiota:microsoft-kiota-serialization-multipart:1.9.2'
 }

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>6.0.1</version>
+            <version>6.0.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
This PR consolidates all open Dependabot PRs into a single PR for easier review and merging.

## Consolidated PRs

- #2566 - bump android-actions/setup-android from 3.2.2 to 4.0.1
- #2565 - bump dependabot/fetch-metadata from 2.4.0 to 3.0.0
- #2557 - bump kiota-dependencies group across 2 directories with 6 updates
- #2551 - bump kiota-dependencies group in /android with 6 updates (subset of #2557)
- #2529 - bump org.junit.jupiter:junit-jupiter-api from 6.0.1 to 6.0.2
- #2522 - bump actions/upload-artifact from 5 to 6

## Changes

### GitHub Actions
- \ndroid-actions/setup-android\: 3.2.2 → 4.0.1
- \dependabot/fetch-metadata\: 2.4.0 → 3.0.0
- \ctions/upload-artifact\: 5 → 6

### Gradle (Kiota dependencies)
- \microsoft-kiota-authentication-azure\: 1.9.0 → 1.9.1
- \microsoft-kiota-http-okHttp\: 1.9.0 → 1.9.1
- \microsoft-kiota-serialization-json\: 1.9.0 → 1.9.1
- \microsoft-kiota-serialization-text\: 1.9.0 → 1.9.1
- \microsoft-kiota-serialization-form\: 1.9.0 → 1.9.1
- \microsoft-kiota-serialization-multipart\: 1.9.0 → 1.9.1

### Maven
- \org.junit.jupiter:junit-jupiter-api\: 6.0.1 → 6.0.2

Once this PR is merged, the individual Dependabot PRs listed above can be closed.