### PR TITLE
chore(deps): consolidate dependabot dependency updates

### DIFF
--- a/.github/workflows/api-level-lint.yml
+++ b/.github/workflows/api-level-lint.yml
@@ -31,7 +31,7 @@ jobs:
         working-directory: ./android
       - name: Upload linting results
         if: failure() && steps.lint.outcome == 'failure'
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: lint-report
           path: ./android/build/reports

--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v3.0.0
+        uses: dependabot/fetch-metadata@v3.1.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -27,14 +27,14 @@ jobs:
         run: ./gradlew build
       - name: Upload Unit Test Results
         if: ${{ always() }}
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: UnitTests
           path: |
             build/reports/tests/test/**
             build/test-results/**
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: drop
           path: |

--- a/.github/workflows/release-please-gha.yml
+++ b/.github/workflows/release-please-gha.yml
@@ -29,7 +29,7 @@ jobs:
           private-key: ${{ secrets.RELEASE_PLEASE_TOKEN_PROVIDER_PEM }}
 
       - name: Release Please
-        uses: googleapis/release-please-action@v4
+        uses: googleapis/release-please-action@v5
         with:
           token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json

--- a/.github/workflows/validate-public-api-surface.yml
+++ b/.github/workflows/validate-public-api-surface.yml
@@ -35,14 +35,14 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload patch file as artifact
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         continue-on-error: true
         with:
           name: patch
           path: '*.patch'
       - name: Upload explanations file as artifact
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         continue-on-error: true
         with:
           name: explanations

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     dependencies {
         classpath "com.gradle:gradle-enterprise-gradle-plugin:3.19.2"
         classpath "gradle.plugin.com.github.viswaramamoorthy:gradle-util-plugins:0.1.0-RELEASE"
-        classpath "com.github.ben-manes:gradle-versions-plugin:0.53.0"
+        classpath "com.github.ben-manes:gradle-versions-plugin:0.54.0"
         classpath "com.android.tools.build:gradle:8.13.2"
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.13.2</version>
+            <version>2.14.0</version>
         </dependency>
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>


### PR DESCRIPTION
Combines the following dependabot PRs into a single update:

- Bump actions/upload-artifact from 6 to 7 (#2588)
- Bump com.google.code.gson:gson from 2.13.2 to 2.14.0 (#2580)
- Bump googleapis/release-please-action from 4 to 5 (#2579)
- Bump com.github.ben-manes:gradle-versions-plugin from 0.53.0 to 0.54.0 (#2574)
- Bump dependabot/fetch-metadata from 3.0.0 to 3.1.0 (#2573)

Once this PR is merged, the individual dependabot PRs can be closed.