### PR TITLE
Fix validatePackageContents.ps1 failing on build-ci pipeline

### DIFF
--- a/scripts/validatePackageContents.ps1
+++ b/scripts/validatePackageContents.ps1
@@ -26,8 +26,6 @@ $expectedFiles = @(
   "-javadoc.jar.asc",
   "-sources.jar",
   "-sources.jar.asc",
-  ".module",
-  ".module.asc",
   ".pom",
   ".pom.asc",
   ".jar",


### PR DESCRIPTION
## Problem
The `Inspect contents of local Maven cache` step in the build-ci pipeline fails because `scripts/validatePackageContents.ps1` requires `.module` and `.module.asc` files.

## Cause
After the gradle-to-maven migration (#2613), the build uses Maven (javadoc/source/gpg plugins), which does not produce Gradle Module Metadata (`.module` / `.module.asc`). The script still expected them, so `Test-Path` failed and the script exited 1.

## Fix
Removed `.module` and `.module.asc` from the `\` list. The remaining expected artifacts (jar, sources, javadoc, pom, and their `.asc` signatures) are still produced by the Maven build.