### PR TITLE
Use Maven task in release pipeline

### DIFF
--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -101,21 +101,53 @@ extends:
                 inputs:
                   artifactsFeeds: 'GraphDeveloperExperiences_Public'
 
-              - script: ./mvnw install -Psigning --no-transfer-progress
+              - task: Maven@4
                 displayName: Publish to local Maven for verification
                 condition: contains(variables['build.sourceBranch'], 'refs/tags/v')
+                inputs:
+                  mavenPomFile: 'pom.xml'
+                  goals: 'install'
+                  options: '-Psigning --no-transfer-progress'
+                  publishJUnitResults: false
+                  javaHomeOption: 'JDKVersion'
+                  jdkVersionOption: '1.21'
+                  jdkArchitectureOption: 'x64'
 
-              - script: ./mvnw install -Psigning --no-transfer-progress
+              - task: Maven@4
                 displayName: Publish to local Maven for verification
                 condition: not(contains(variables['build.sourceBranch'], 'refs/tags/v'))
+                inputs:
+                  mavenPomFile: 'pom.xml'
+                  goals: 'install'
+                  options: '-Psigning --no-transfer-progress'
+                  publishJUnitResults: false
+                  javaHomeOption: 'JDKVersion'
+                  jdkVersionOption: '1.21'
+                  jdkArchitectureOption: 'x64'
 
-              - script: ./mvnw deploy -Psigning --no-transfer-progress -DaltDeploymentRepository=ADO::default::file://$(Build.SourcesDirectory)/target/staging-deploy
+              - task: Maven@4
                 displayName: Stage artifacts for ESRP
                 condition: contains(variables['build.sourceBranch'], 'refs/tags/v')
+                inputs:
+                  mavenPomFile: 'pom.xml'
+                  goals: 'deploy'
+                  options: '-Psigning --no-transfer-progress -DaltDeploymentRepository=ADO::default::file://$(Build.SourcesDirectory)/target/staging-deploy'
+                  publishJUnitResults: false
+                  javaHomeOption: 'JDKVersion'
+                  jdkVersionOption: '1.21'
+                  jdkArchitectureOption: 'x64'
 
-              - script: ./mvnw deploy -Psigning --no-transfer-progress -DaltDeploymentRepository=ADO::default::file://$(Build.SourcesDirectory)/target/staging-deploy
+              - task: Maven@4
                 displayName: Stage artifacts for ESRP
                 condition: not(contains(variables['build.sourceBranch'], 'refs/tags/v'))
+                inputs:
+                  mavenPomFile: 'pom.xml'
+                  goals: 'deploy'
+                  options: '-Psigning --no-transfer-progress -DaltDeploymentRepository=ADO::default::file://$(Build.SourcesDirectory)/target/staging-deploy'
+                  publishJUnitResults: false
+                  javaHomeOption: 'JDKVersion'
+                  jdkVersionOption: '1.21'
+                  jdkArchitectureOption: 'x64'
 
               - pwsh: |
                   $pomXml = [xml](Get-Content pom.xml -Raw)


### PR DESCRIPTION
## Summary

- replace Maven Wrapper `install` and `deploy` commands with `Maven@4` tasks
- preserve Java 21, signing, branch conditions, and ESRP staging behavior
- avoid direct Maven Wrapper downloads from Maven Central in network-isolated builds

## Validation

- confirmed the pipeline YAML contains no remaining `./mvnw` invocations
- confirmed the resulting diff has no whitespace errors